### PR TITLE
pc - update README.md with clearer instructions for localhost setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-GIT_PROVIDER_URL=github.com
-OMNIAUTH_STRATEGY=github
-OMNIAUTH_PROVIDER_KEY= <your omniauth provider key>
-OMNIAUTH_PROVIDER_SECRET= <your omniauth provider secret>
-
-MACHINE_USER_NAME= <your machine user's name>
-MACHINE_USER_KEY= <your machine user's key or password>
-
-DEVISE_SECRET_KEY= <a random alphunmeric string used by devise to salt its sessions>

--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,3 @@ pickle-email-*.html
 
 jenkins.yml
 .env*
-!.env.example

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ rvm:
 # the default script option for Travis and most Rails projects will want this
 # when starting out as this usually runs `rake test`.
 
+services:
+  - postgresql
+
 script:
   - bin/rake db:migrate RAILS_ENV=test
   - bin/rake

--- a/README.md
+++ b/README.md
@@ -64,3 +64,19 @@ This is a rails application that allows for course management in conjunction wit
 ## Configuration
   - /users/auth/github/callback is the omniauth callback path
   - TODO: fill out the documentation
+
+## Getting Started on Localhost
+
+You will need:
+* Clone the repo, and run `bundle install`
+* Make sure that Postgres is running locally
+   - You might need to do `createuser -s -r postgres` per this [StackOverflow post](https://stackoverflow.com/questions/7863770/rails-and-postgresql-role-postgres-does-not-exist)
+* `bundle exec rake db:create`
+* `bundle exec rake db:migrate`
+* Do  `cp dotenv.example .env`
+   * Note that `.env` is a file in the `.gitignore` because you will configure it with secrets
+   * Therefore it SHOULD NOT be committed to github
+* Edit `.env` with the appropriate values.  These are NOT shell environment variables, but rather variables
+   that are read into the Rails environment by the [dotenv-rails](https://github.com/bkeepers/dotenv) gem.
+* Finally, run `rails s` and the application should come up.
+

--- a/dotenv.example
+++ b/dotenv.example
@@ -1,0 +1,21 @@
+# NOTE: There should be no spaces around = in assigments in shell syntax
+# Copy this example file using
+#   cp dotenv.example .env
+# Then edit the values below to be the correct ones
+
+# These should not normally need to be edited
+GIT_PROVIDER_URL=github.com
+OMNIAUTH_STRATEGY=github
+
+# Get these by creating a new OAuth app in Github
+OMNIAUTH_PROVIDER_KEY=<your omniauth provider key>
+OMNIAUTH_PROVIDER_SECRET=<your omniauth provider secret>
+
+# Provide a github user, and an access token for that github user
+# The scopes should be user:email,admin:org
+
+MACHINE_USER_NAME=<your machine user's name>
+MACHINE_USER_KEY=<your machine user's key>
+
+# This can be any arbitrary value; it is used for crytographic security
+DEVISE_SECRET_KEY=<a random alphunmeric string used by devise to salt its sessions>


### PR DESCRIPTION
The instructions in README.md for setup on localhost were not very clear.   It may have created the impression that the contents of .env were actually a shell script for defining environment variables, but that is not the case.

Instead, they are intended for use with the `dotenv-rails` Gem.  This change makes that clear.