### PR TITLE
pc - don't show hidden courses on index page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ rvm:
 # the default script option for Travis and most Rails projects will want this
 # when starting out as this usually runs `rake test`.
 
+services:
+  - postgresql
+
 script:
   - bin/rake db:migrate RAILS_ENV=test
   - bin/rake

--- a/app/controllers/visitors_controller.rb
+++ b/app/controllers/visitors_controller.rb
@@ -2,8 +2,7 @@ class VisitorsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    #@courses = Course.where(hidden: false)
-    @courses= Course.all
+    @courses = Course.where.not(hidden: true)
     # if user is logged in then render list of enrolled courses & active courses they can join
     # otherwise display a login button and list of active courses they might join
   end

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -36,7 +36,7 @@
       </thead>
       <tbody>
         <% @courses.each do |course| %>
-          <tr>
+          <tr class="is_course_row">
             <td>
               <%= 
                 if can? :mange, course

--- a/test/controllers/visitors_controller_test.rb
+++ b/test/controllers/visitors_controller_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
+require 'helpers/octokit_stub_helper'
 
 class VisitorsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do
   #   assert true
   # end
   include Devise::Test::IntegrationHelpers
+  include OctokitStubHelper
 
   test "homepage should return 200 success" do
     get root_url
@@ -41,5 +43,35 @@ class VisitorsControllerTest < ActionDispatch::IntegrationTest
     get signout_path
     assert_redirected_to root_url
   end
+
+  test "when you are logged in as a regular user home page has only non-hidden courses" do
+    # sign in here
+    @user = users(:tim)
+    sign_in @user
+ 
+    stub_course_organization("course-org-1")
+    stub_course_organization("course-org-2")
+    stub_course_organization("course-org-3")
+
+    hidden_course = Course.create!({ name: "hidden-course-1", course_organization: "course-org-1", hidden: true })
+    visible_course = Course.create!({ name: "visible-course-2", course_organization: "course-org-2", hidden: false })
+    course_with_hidden_nil = Course.create!({ name: "course-3", course_organization: "course-org-3", hidden: nil })
+
+    visible_course_count = Course.where.not(hidden: true).count
+
+    get root_url
+    assert_response :success
+    assert_select 'tr.is_course_row', count: visible_course_count
+  end
+
+  private
+
+  def stub_course_organization(org)
+    stub_organization_membership_admin_in_org(org, ENV["MACHINE_USER_NAME"])
+    stub_organization_is_an_org(org)
+    stub_updating_org_membership(org)
+  end
+
+
 
 end

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -3,7 +3,9 @@
 course1:
   name: course1
   course_organization: org1
+  hidden: false
 
 course2:
   name: course2
   course_organization: org2
+  hidden: false


### PR DESCRIPTION
Hidden courses should not be shown on the index page.

We added that code into the app previously and it worked in test, but not in production, so we backed the change out.   I discovered that the problem was that we were checking 

```
   @courses = Course.where(hidden: false)
```

when we should have been checking:

```
    @courses = Course.where.not(hidden: true)
```

The problem was that when we added the new `hidden` field, we didn't populate the null values with false.  Thus the first query gave us no courses at all, since hidden was not false for any of them in the production database.  

This could have been avoided if we had followed this advice:

<https://thoughtbot.com/blog/avoid-the-threestate-boolean-problem>

The "right" way to fix this was with a migration.  Instead, I just bravely/recklessly fixed the data with a live SQL query on the production database to set all of the values to `true` (i.e. hide all courses) except for the course that I just added for Fall 2019.

I also added a test to check that the count of the course rows on the home page matches the count of not hidden courses.   There is some weirdness at the moment with text fixtures that we may want to address in a future pull request.  I'd rather have the database start in a clean state with each test (as is the practice at a certain place I used to work.. ).   That can wait for a future pull request.