### PR TITLE
pc - fix postgres on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ rvm:
 # the default script option for Travis and most Rails projects will want this
 # when starting out as this usually runs `rake test`.
 
+services:
+  - postgresql
+
 script:
   - bin/rake db:migrate RAILS_ENV=test
   - bin/rake


### PR DESCRIPTION
postgres now has to be explicitly requested in the .travis.yml file; otherwise it is not possible to run the test cases that depend on Postgres on Travis CI.