### PR TITLE
Pc better error handling for invites

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,9 +23,9 @@ when "development"
   #   [ "Fake  9 User", "fakeuser09" ],
   #   [ "Fake 10 User", "fakeuser10" ]
   # ]
-  users.each do |name, username|
-    User.create!( name: name, username: username, email: "#{username}@example.org", password: SecureRandom.alphanumeric )
-  end
+  # users.each do |name, username|
+  #   User.create!( name: name, username: username, email: "#{username}@example.org", password: SecureRandom.alphanumeric )
+  # end
 when "production"
 
 when "test"

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -128,6 +128,47 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to course_url(course)
   end
 
+  def test_update_should_hide_course
+    course_name = 'fake course_name'
+    course_organization = "course_org"
+
+    stub_organization_membership_admin_in_org(course_organization, ENV["MACHINE_USER_NAME"])
+    stub_organization_is_an_org(course_organization)
+
+    assert_nil Course.find_by(name: course_name)
+    course = Course.create(name: course_name, course_organization: course_organization, hidden: false)
+
+    patch course_url(course), params: { course: { hidden: 1 } }
+
+    after = Course.find_by(name: course_name)
+    assert_not_nil after
+    assert after.hidden
+
+    get courses_url
+    assert_response :ok
+  end
+
+  def test_update_should_unhide_course
+    course_name = 'fake course_name'
+    course_organization = "course_org"
+
+    stub_organization_membership_admin_in_org(course_organization, ENV["MACHINE_USER_NAME"])
+    stub_organization_is_an_org(course_organization)
+
+    assert_nil Course.find_by(name: course_name)
+    course = Course.create(name: course_name, course_organization: course_organization, hidden: false)
+
+    patch course_url(course), params: { course: { hidden: 0 } }
+
+    after = Course.find_by(name: course_name)
+    assert_not_nil after
+    refute after.hidden
+
+    get root_url
+    assert_response :ok
+    assert_select 'a.list-group-item-info'
+  end
+
   test "should destroy course" do
     assert_difference('Course.count', -1) do
       delete course_url(@course)

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -15,7 +15,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     stub_organization_membership_admin_in_org(@org, ENV["MACHINE_USER_NAME"])
     stub_organization_is_an_org(@org)
-    @enroll_success_flash_notice = %Q[You were successfully enrolled in #{@course.name}! View you invitation <a href="https://github.com/orgs/#{@course.course_organization}/invitation">here</a>.]
+    @enroll_success_flash_notice = %Q[You were successfully invited to #{@course.name}! View and accept your invitation <a href="https://github.com/orgs/#{@course.course_organization}/invitation">here</a>.]
   end
 
   test "should get index" do

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -2,10 +2,10 @@
 
 course1:
   name: course1
-  course_organization: org1
+  course_organization: test-course-org
   hidden: false
 
 course2:
   name: course2
-  course_organization: org2
+  course_organization: test-course-org-two
   hidden: false


### PR DESCRIPTION
In this pull request, I add some better error handling for the case where inviting a user to an organization fails.    

The new code checks to see if the Octokit call works before adding rows in the database.  It also passes along the error message from the exception to help with debugging problems when they occur.

I also clarify that the code *invites* the user; it does not add the user.   

There are also a few commits to clean up the seeds and fixtures.   There is more work to be done there, but that should be done in a separate pull request.