### PR TITLE
pc - add hack for umail.ucsb.edu to ucsb.edu email conversion

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -117,6 +117,13 @@ class CoursesController < ApplicationController
       email_to_student = Hash.new
       course.roster_students.each do |student|
         email_to_student[student.email] = student
+        if student.email.end_with? '@umail.ucsb.edu'
+          new_email = student.email.gsub('@umail.ucsb.edu','@ucsb.edu')
+          email_to_student[new_email] = student
+        elsif student.email.end_with? '@ucsb.edu'
+          old_email = student.email.gsub('@ucsb.edu','@umail.ucsb.edu')
+          email_to_student[old_email] = student
+        end
       end
 
       session_user.emails.each do |email|


### PR DESCRIPTION
This PR addresses the situation where UCSB student emails are being converted from `user@umail.ucsb.edu` (the format that still appears on course rosters downloaded from eGrades) to `user@ucsb.edu`.

It is a risky change because it is not covered by tests.  Writing proper test cases for this would require considerable refactoring; the code is not currently well structured to test this.    That should eventually be done, but at the moment, it's more important to deliver value for our users.    

It has been tested only by putting in a `pry` statement on the data structure and checking that both `@umail.ucsb.edu` and `@ucsb.edu` addresses get added into the hash under both formats.    That's not perfect, but it may have to do.