### PR TITLE
pc - add username/uid to users page to help debug OAuth issues

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,6 +16,8 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>Username</th>
+          <th>uid</th>
           <th>Admin</th>
           <th></th>
           <th>Instructor</th>
@@ -26,6 +28,8 @@
         <% @users.each do |user| %>
           <tr>
             <td><%= user.name %></td>
+            <td><%= user.username %></td>
+            <td><%= user.uid %></td>
             <td><%= (user.has_role? :admin) ? "True" : "False" %></td>
               <td>
                 <%= form_for user do |f| %>


### PR DESCRIPTION
This PR adds username and uid to the users page.  

This is intended to help when debugging problems that arise when github users change their username (but keep the same uid).