### PR TITLE
Pc update email name username from GitHub at login

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,7 +12,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     def create_session_octokit(auth)
       token = auth.credentials.token
       session[:token] = token
-      puts token
       client = Octokit::Client.new :access_token => token
       session[:user_emails] = client.emails
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,24 @@ class User < ApplicationRecord
   delegate :can?, :cannot?, :to => :ability
 
   def self.from_omniauth(auth)
+    user = where(provider: auth.provider, uid: auth.uid).first
+    if user.nil?
+      User.create(
+        provider: auth.provider,
+        uid: auth.uid,
+        email: auth.info.email,
+        name: auth.info.name,
+        username: auth.info.nickname,
+        password: Devise.friendly_token[0,20],
+      )
+    else
+      user.update(
+        email: auth.info.email,
+        name: auth.info.name,
+        username: auth.info.nickname,
+      )
+    end
+
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email
       user.name = auth.info.name

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,6 +16,8 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>Username</th>
+          <th>uid</th>
           <th>Admin</th>
           <th></th>
           <th>Instructor</th>
@@ -26,6 +28,8 @@
         <% @users.each do |user| %>
           <tr>
             <td><%= user.name %></td>
+            <td><%= user.username %></td>
+            <td><%= user.uid %></td>
             <td><%= (user.has_role? :admin) ? "True" : "False" %></td>
               <td>
                 <%= form_for user do |f| %>


### PR DESCRIPTION
In this PR we fix a bug where students that have changed their github username are not able to use the github linker.    

In the past, the username and "name" fields (given name) were updated in the database only at the first login from OAuth.  If a user than changed their username, subsequent attempts to add courses failed.    This PR should fix that.

In addition, if a student changed their given name in the past (e.g. from Christopher to Chris) or added a given name where it was previously blank, that would not be picked up.   Now, each time the user logs out of github completely, and then logs back into the github linker via OAuth, the information is updated.

