### PR TITLE
pc/fs/yr - replace new course form with button on course index page a…

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -9,12 +9,9 @@ and render differently depending on whether or not the user is privlidged %>
   course you would like to manage from the list of courses you
   have access to. From this view you can create, edit, or delete
   your courses. </p>
-  <div class="panel panel-default">
-    <div class="panel-heading">Create a new course</div>
-    <div class="panel-body">
-      <%= render 'form', course: Course.new %>
-    </div>
-  </div>
+    <p class="js-new-course">
+    <%= link_to 'New Course', new_course_path, class: "btn btn-default ", role: "button" %>
+    </p>
 <% else %>
   <h1>Currently Enrolled Courses List</h1>
   <p> If you are looking to enroll in a course, head over to the <%= link_to 'home', root_url %> page.
@@ -23,12 +20,13 @@ and render differently depending on whether or not the user is privlidged %>
 
 <div class="row">
   <div class="col-sm-6">
+     <!--
       <%# search the course list %>
       <div class="input-group">
         <span class="input-group-addon" id="basic-addon1">Course Name</span>
         <input id="courses_search" type="text" class="form-control" placeholder="Search..." onkeyup="filter_list_by_keyword()">
       </div>
-
+      -->
     <%# table containing the course list %>
     <table class="table table-sm" id="course_list">
       <thead>
@@ -88,4 +86,3 @@ function filter_list_by_keyword() {
 
 <br>
 
-<!-- <%= link_to 'New Course', new_course_path %> -->

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -47,6 +47,15 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'p.js-new-course a[href=?]', new_course_path
   end
 
+  test "noninstructors should not be able to see the add course button" do
+    users(:tim).add_role(:user)
+    sign_in users(:tim)
+
+    get courses_url
+    assert_response :success
+    assert_select 'p.js-new-course a[href=?]', new_course_path, count:0
+  end
+
   test "instructors should not be able to see other instructors view_ta page" do
     users(:tim).add_role(:instructor)
     users(:tim).add_role(:instructor, @course)

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -38,6 +38,15 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "instructors should be able to see the add course button" do
+    users(:tim).add_role(:instructor)
+    sign_in users(:tim)
+
+    get courses_url
+    assert_response :success
+    assert_select 'p.js-new-course a[href=?]', new_course_path
+  end
+
   test "instructors should not be able to see other instructors view_ta page" do
     users(:tim).add_role(:instructor)
     users(:tim).add_role(:instructor, @course)


### PR DESCRIPTION
In this PR, we try to make the course index page look a little nicer, because we are about to possibly clutter it up with new features.   

Specifically:
* Remove the new course form, and replace it with a link to the course new page 
* Remove the search box (it's commented out in the code) because it isn't really needed yet, 
  and is taking up space and cluttering the page visually.