### PR TITLE
fs - Added GitHub Id w/ hyperlink to show Roster_Student page

### DIFF
--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -17,12 +17,17 @@
 
 <p>
   <strong>Email:</strong>
-  <%= @roster_student.email %>
+  <a href="mailto:<%= @roster_student.email %>"><%= @roster_student.email %> </a>
 </p>
 
 <p>
   <strong>Enrolled:</strong>
   <%= @roster_student.enrolled ? "True" : "False" %>
+</p>
+
+<p>
+  <strong>Github ID:</strong>
+  <a href="https://github.com/<%= @roster_student.username %>"><%= @roster_student.username %> </a>
 </p>
 
 

--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -25,11 +25,16 @@
   <%= @roster_student.enrolled ? "True" : "False" %>
 </p>
 
+<% if @roster_student.username.nil? %>
+<p>
+  <strong>Github ID:</strong><span class="js-no-github-id"> Unknown</span>
+</p>
+<% else %>
 <p>
   <strong>Github ID:</strong>
-  <a href="https://github.com/<%= @roster_student.username %>"><%= @roster_student.username %> </a>
+  <a class="js-github-id" href="https://github.com/<%= @roster_student.username %>"><%= @roster_student.username %></a>
 </p>
-
+<% end %>
 
 <%= link_to 'Edit', edit_course_roster_student_path(@parent, @roster_student), :class => "btn btn-outline-secondary" %> |  
 <%= link_to 'Back', course_path(@parent), :class => "btn btn-outline-secondary" %>

--- a/test/controllers/roster_students_controller_test.rb
+++ b/test/controllers/roster_students_controller_test.rb
@@ -11,6 +11,33 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
     @user = users(:wes)
     @user.add_role(:admin)
     sign_in @user
+
+    @user2 = User.create!(
+      name: 'Chris',
+      username: 'cgaucho',
+      uid: 1234567,
+      provider: 'GitHub',
+      email: 'cgaucho@example.edu',
+      password: 'a9sd8ua98fu9as'
+    )
+    @roster_student_with_github = RosterStudent.create!(
+      perm: 1234,
+      first_name: 'Chris',
+      last_name: 'Gaucho',
+      email: 'cgaucho@example.edu',
+      course: @course2,
+      enrolled: false,
+      user: @user2
+    )
+    @roster_student_with_no_github = RosterStudent.create!(
+      perm: 5678,
+      first_name: 'Lyn',
+      last_name: 'DelPlaya',
+      email: 'ldelplaya@example.edu',
+      course: @course2,
+      enrolled: false,
+      user: nil
+    )
   end
 
   test "should get new" do
@@ -71,6 +98,18 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
   test "should show roster_student" do
     get course_roster_student_path(:course_id=> @roster_student.course_id, :id=> @roster_student.id)
     assert_response :success
+  end
+
+  test "should show github id if roster_student has one" do
+    get course_roster_student_path(:course_id=> @roster_student_with_github.course_id, :id=> @roster_student_with_github.id)
+    assert_response :success
+    assert_select 'a.js-github-id[href=?]','https://github.com/cgaucho'
+  end
+
+  test "should not show github id if roster_student has none" do
+    get course_roster_student_path(:course_id=> @roster_student_with_no_github.course_id, :id=> @roster_student_with_no_github.id)
+    assert_response :success
+    assert_select 'span.js-no-github-id'
   end
 
   test "should get edit" do


### PR DESCRIPTION
In this PR, I've added a roster student's GitHub ID to the show student page (views/courses/roster_students/show.html.erb) where it's now displayed alongside the student's other information:
<img width="245" alt="Screen Shot 2019-10-08 at 2 12 57 PM" src="https://user-images.githubusercontent.com/34611522/66433708-c392e280-e9d5-11e9-8e6f-5e65a68a2198.png">

The username field is also a hyperlink to the student's GitHub profile similar to what can be accessed from the main student roster table of the class. I checked to ensure that the page displays fine when no GitHub user is associated with the student and it's all good; the field simply shows nothing: 

<img width="228" alt="Screen Shot 2019-10-08 at 2 18 23 PM" src="https://user-images.githubusercontent.com/34611522/66434077-93980f00-e9d6-11e9-8e70-858b42e36a8e.png">

Additionally, I converted the student's email address field to a mailto hyperlink to make contact easy. This can be reverted quickly if it's not desired functionality.