### PR TITLE
Added omniauth-rails_csrf_protection gem and updated auth calls to POST

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'kaminari'
 
 gem "actionview", ">= 5.1.6.2"
+
+gem 'omniauth-rails_csrf_protection', '~> 0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,9 @@ GEM
     omniauth-oauth2 (1.5.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     pg (0.21.0)
     pg (0.21.0-x86-mingw32)
@@ -292,6 +295,7 @@ DEPENDENCIES
   omniauth
   omniauth-github
   omniauth-gitlab
+  omniauth-rails_csrf_protection (~> 0.1)
   pg (~> 0.18)
   pry-byebug
   puma (~> 3.7)

--- a/app/views/layouts/_nav_links_for_auth.html.erb
+++ b/app/views/layouts/_nav_links_for_auth.html.erb
@@ -24,7 +24,7 @@
   </li>
 <% else %>
   <li><p class="navbar-btn">
-    <%= link_to user_github_omniauth_authorize_path, class: 'btn btn-info' do %>
+    <%= link_to user_github_omniauth_authorize_path, method: :post, class: 'btn btn-info' do %>
       <%= fa_icon 'github', text: 'Sign in' %>
     <% end %>
   </p></li>

--- a/app/views/visitors/_splash.html.erb
+++ b/app/views/visitors/_splash.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-sm-3"></div>
     <div class="col-sm-6 text-center">
-      <%= button_to user_github_omniauth_authorize_path, method: :get, class: 'btn btn-info btn-lg' do %>
+      <%= button_to user_github_omniauth_authorize_path, method: :post, class: 'btn btn-info btn-lg' do %>
         <%= fa_icon 'github', text: 'Sign in with Github' %>
       <% end %>
     </div>

--- a/test/controllers/visitors_controller_test.rb
+++ b/test/controllers/visitors_controller_test.rb
@@ -31,7 +31,7 @@ class VisitorsControllerTest < ActionDispatch::IntegrationTest
     @user = users(:tim)
     @user.add_role(:admin)
     # sign_in @user
-    get user_github_omniauth_authorize_path
+    post user_github_omniauth_authorize_path
     #For some reason, this generates this print statement when testing:
     #I, [2018-02-16T16:54:53.885865 #1938]  INFO -- omniauth: (github) Request phase initiated.
     assert path.include?('github')


### PR DESCRIPTION
This PR resolves some not-flagrant-but-also-kinda-sketchy authentication practices present in the app's code. This resolves the [CVE 2015 9284](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284) flagged by GitHub in the repo's security section. Though our configuration would not have allowed the kind of attack discussed in the vulnerability report, it still contains certain discouraged practices, namely the use of GET calls for Omniauth authorization. Specifically, this PR makes the following simple changes:

- The omniauth-rails_csrf_protection gem is added to the Gemfile. This gem just prevents any Omniauth calls from being anything other than a POST call unless explicitly overriden.
- The navigation bar and splash page sign-in links have been updated to POST calls to the authorization method.
- The visitors_controller_test.rb "user is redirected to github sign in" test has been updated to use a POST call when testing the auth method. This test would fail without this change thanks to the enforced POST usage from the omniauth-rails_csrf_protection gem.

These changes reflect those [recommended by the Omniauth developers](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284). This PR closes #80 