### PR TITLE
Add table of student's repositories to show roster_student page

### DIFF
--- a/app/controllers/courses/roster_students_controller.rb
+++ b/app/controllers/courses/roster_students_controller.rb
@@ -88,10 +88,11 @@ module Courses
 
     def find_org_repos
       organization_repos = machine_user.organization_repositories(@parent.course_organization)
-      repo_list = ""
-      filtered_repos = organization_repos.select {|repo| repo.name.downcase.include?(@roster_student.username.downcase) }
-      filtered_repos.each do |repo|
-        repo_list += repo.name
+      filtered_repos = []
+      if organization_repos.respond_to? :select
+        filtered_repos = organization_repos.select do |repo|
+          repo.name.downcase.include?(@roster_student.username.downcase)
+        end
       end
       filtered_repos
     end
@@ -101,7 +102,8 @@ module Courses
       student_list = @parent.roster_students
       contributors = student_list.select do |student|
         unless student.username.nil?
-          next(repo_name.downcase.include?((student.username).downcase) && student.username != @roster_student.username)
+          does_not_equal_current_student = student.username != @roster_student.username
+          next(repo_name.downcase.include?((student.username).downcase) && does_not_equal_current_student)
         else
           next(false)
         end

--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -36,5 +36,28 @@
 </p>
 <% end %>
 
+<% unless @roster_student.username.nil? %>
+<p>
+  <strong>User Repositories:</strong>
+  <table class="table">
+    <thead>
+    <tr>
+      <th>Repository</th>
+      <th>Other Contributors</th>
+      <th>Last Modified</th>
+    </tr>
+    </thead>
+    <% find_org_repos.each do |repo| %>
+      <tr>
+        <td><a href=<%= repo.html_url %>><%= repo.name %></td>
+        <td><%= find_other_contributors(repo.name) %></td>
+        <td><%= repo.updated_at %></td>
+      </tr>
+    <% end %>
+  </table>
+</p>
+
+<% end %>
+
 <%= link_to 'Edit', edit_course_roster_student_path(@parent, @roster_student), :class => "btn btn-outline-secondary" %> |  
 <%= link_to 'Back', course_path(@parent), :class => "btn btn-outline-secondary" %>

--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -37,7 +37,7 @@
 <% end %>
 
 <% unless @roster_student.username.nil? %>
-<p>
+<p class="repo-list-table">
   <strong>User Repositories:</strong>
   <table class="table">
     <thead>
@@ -57,6 +57,8 @@
   </table>
 </p>
 
+<% else %>
+  <p class="no-repo-list-table"> </p>
 <% end %>
 
 <%= link_to 'Edit', edit_course_roster_student_path(@parent, @roster_student), :class => "btn btn-outline-secondary" %> |  

--- a/test/controllers/roster_students_controller_test.rb
+++ b/test/controllers/roster_students_controller_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
+require 'helpers/octokit_stub_helper'
 
 class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
 
   include Devise::Test::IntegrationHelpers
+  include OctokitStubHelper
 
   setup do
     @course = courses(:course1)
@@ -100,16 +102,20 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should show github id if roster_student has one" do
+  test "should show github id and repo table if roster_student has one" do
+    course = Course.find(@roster_student_with_github.course_id)
+    stub_org_repo_list_for_github_id(course.course_organization)
     get course_roster_student_path(:course_id=> @roster_student_with_github.course_id, :id=> @roster_student_with_github.id)
     assert_response :success
     assert_select 'a.js-github-id[href=?]','https://github.com/cgaucho'
+    assert_select 'p.repo-list-table'
   end
 
-  test "should not show github id if roster_student has none" do
+  test "should not show github id or repo table if roster_student has none" do
     get course_roster_student_path(:course_id=> @roster_student_with_no_github.course_id, :id=> @roster_student_with_no_github.id)
     assert_response :success
     assert_select 'span.js-no-github-id'
+    assert_select 'p.no-repo-list-table'
   end
 
   test "should get edit" do

--- a/test/helpers/octokit_stub_helper.rb
+++ b/test/helpers/octokit_stub_helper.rb
@@ -142,7 +142,18 @@ module OctokitStubHelper
       to_return(status: 200,
                 body: "#{octokit_organization_membership_admin_in_org(org_name, username)}",
                 headers: {'Content-Type'=>'application/json'})
+  end
 
+  def stub_org_repo_list_for_github_id(org_name)
+    stub_request(:get, "https://api.github.com/orgs/" + org_name + "/repos").
+      with(  headers: {
+        'Accept'=>'application/vnd.github.v3+json',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Authorization'=>'token a3a3b41ce3acedb58eb70c044b9dd5189896122c',
+        'Content-Type'=>'application/json',
+        'User-Agent'=>'Octokit Ruby Gem 4.8.0'
+      }).
+    to_return(status: 200, body: "", headers: {})
   end
 
 end

--- a/test/helpers/octokit_stub_helper.rb
+++ b/test/helpers/octokit_stub_helper.rb
@@ -149,7 +149,6 @@ module OctokitStubHelper
       with(  headers: {
         'Accept'=>'application/vnd.github.v3+json',
         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization'=>'token a3a3b41ce3acedb58eb70c044b9dd5189896122c',
         'Content-Type'=>'application/json',
         'User-Agent'=>'Octokit Ruby Gem 4.8.0'
       }).


### PR DESCRIPTION
This pull request partially addresses issue #89. It implements a rudimentary substring matching way of listing a student's GitHub repositories within a course organization. For reasons elaborated on in exhaustive detail [here](https://github.com/project-anacapa/anacapa-github-linker/issues/89#issuecomment-548261898), it is resource prohibitive to use GitHub's API to generate a list of repositories in an organization that a user has either created or contributed to. For this reason, @pconrad and I decided to implement this functionality for the time being by simply showing repositories in the organization whose name contain the user's GitHub organization.

It implements a table on the show roster_student page that contains three things:
* The repository's name, which is a hyperlink to the repository on GitHub.com
* Other contributors to the repository: this uses the same matching logic as explained above to find any other student's GitHub ID contained in the repository's name and lists their name. 
* The date the repository was last modified.

The show roster_student page now looks like this when the student has an associated GitHub ID: 
<img width="1133" alt="Screen Shot 2019-11-04 at 11 23 46 AM" src="https://user-images.githubusercontent.com/34611522/68167770-84e04180-ff1b-11e9-913e-539f4e73008b.png">
