### PR TITLE
Enabled auto pagination as a stopgap fix

### DIFF
--- a/lib/Octokit_Wrapper.rb
+++ b/lib/Octokit_Wrapper.rb
@@ -9,9 +9,7 @@ module Octokit_Wrapper
     end
 
     def self.user_with(token)
-      client = Octokit::Client.new :access_token => token
-      client.auto_paginate = true
-      client
+      Octokit::Client.new :access_token => token
     end
   end
 end

--- a/lib/Octokit_Wrapper.rb
+++ b/lib/Octokit_Wrapper.rb
@@ -9,7 +9,9 @@ module Octokit_Wrapper
     end
 
     def self.user_with(token)
-      Octokit::Client.new :access_token => token
+      client = Octokit::Client.new :access_token => token
+      client.auto_paginate = true
+      client
     end
   end
 end

--- a/test/helpers/octokit_stub_helper.rb
+++ b/test/helpers/octokit_stub_helper.rb
@@ -37,15 +37,24 @@ module OctokitStubHelper
   end
   
   def stub_check_user_emails(email)
+    stub_request(:get, "https://api.github.com/user/emails?per_page=100").
+        with(  headers: {
+            'Accept'=>'application/vnd.github.v3+json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type'=>'application/json',
+            'User-Agent'=>'Octokit Ruby Gem 4.8.0'
+        }).to_return(status: 200,
+                     body: octokit_get_emails(email),
+                     headers: {'Content-Type'=>'application/json'})
     stub_request(:get, "https://api.github.com/user/emails").
-      with(  headers: {
-        'Accept'=>'application/vnd.github.v3+json',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Content-Type'=>'application/json',
-        'User-Agent'=>'Octokit Ruby Gem 4.8.0'
-        }).to_return(status: 200, 
-                      body: octokit_get_emails(email), 
-                      headers: {'Content-Type'=>'application/json'})
+        with(  headers: {
+            'Accept'=>'application/vnd.github.v3+json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type'=>'application/json',
+            'User-Agent'=>'Octokit Ruby Gem 4.8.0'
+        }).to_return(status: 200,
+                     body: octokit_get_emails(email),
+                     headers: {'Content-Type'=>'application/json'})
   end
 
   def stub_invite_user_to_org(github_id, org_name)


### PR DESCRIPTION
This PR fixes the issue that was causing the user repo list to not work correctly. This was happening because GitHub only returns the first page of results when you request a list of organization repos (30 repos total) unless auto=pagination is enabled. This PR enables auto-pagination. It does make the load of a roster_student page fairly slow for large organizations so in a later change, the repo list will be factored out into a separate page.