### PR TITLE
Added repo purge job for course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -120,7 +120,7 @@ class CoursesController < ApplicationController
 
   # List of course jobs to make available to run
   def course_job_list
-    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob]
+    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob, PurgeCourseReposJob]
   end
   helper_method :course_job_list
 

--- a/app/jobs/purge_course_repos_job.rb
+++ b/app/jobs/purge_course_repos_job.rb
@@ -1,6 +1,6 @@
 class PurgeCourseReposJob < CourseJob
 
-  @job_name = "Purge Course GitHub Repos"
+  @job_name = "Purge Course GitHub Repo Records From DB"
   @job_short_name = "purge_course_repos"
 
   def perform(course_id)

--- a/app/jobs/purge_course_repos_job.rb
+++ b/app/jobs/purge_course_repos_job.rb
@@ -1,0 +1,14 @@
+class PurgeCourseReposJob < CourseJob
+
+  @job_name = "Purge Course GitHub Repos"
+  @job_short_name = "purge_course_repos"
+
+  def perform(course_id)
+    ActiveRecord::Base.connection_pool.with_connection do
+      destroyed_repos = GithubRepo.where(:course_id => course_id.to_i).destroy_all
+      summary = "Purged " + destroyed_repos.size.to_s + " records from the database."
+      create_completed_job_record(summary, course_id)
+    end
+  end
+
+end

--- a/app/jobs/purge_course_repos_job.rb
+++ b/app/jobs/purge_course_repos_job.rb
@@ -5,9 +5,10 @@ class PurgeCourseReposJob < CourseJob
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do
+      super
       destroyed_repos = GithubRepo.where(:course_id => course_id.to_i).destroy_all
       summary = "Purged " + destroyed_repos.size.to_s + " records from the database."
-      create_completed_job_record(summary, course_id)
+      update_job_record_with_completion_summary(summary)
     end
   end
 

--- a/app/jobs/refresh_github_repos_job.rb
+++ b/app/jobs/refresh_github_repos_job.rb
@@ -1,6 +1,6 @@
 class RefreshGithubReposJob < CourseJob
 
-  @job_name = "Refresh Course GitHub Repositories"
+  @job_name = "Refresh Course GitHub Repository Records in DB"
   @job_short_name = "refresh_course_repos"
 
   def perform(course_id)

--- a/app/jobs/students_org_membership_check_job.rb
+++ b/app/jobs/students_org_membership_check_job.rb
@@ -1,6 +1,6 @@
 class StudentsOrgMembershipCheckJob < CourseJob
 
-  @job_name = "Refresh Student Org Membership"
+  @job_name = "Refresh Cached Student Org Membership Statuses"
   @job_short_name = "refresh_org_membership"
 
   def perform(course_id)


### PR DESCRIPTION
This PR closes #110. 

It simply implements a `Purge Course GitHub Repo Records from DB` job that when run, destroys the cached database rows that correspond to each GitHub repos in the course organization.

The GitHub repos themselves are NOT AFFECTED, and if all works as expected, the effect of running this job can be reversed by re-running the `Refresh Course GitHub Repo Records in DB` job.  That one recreates those records.
