### PR TITLE
Admin dashboard and significant job refactoring

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,28 @@
+class AdminController < ApplicationController
+
+  def resource_dashboard
+    authorize! :resource_dashboard, :admin
+  end
+
+  # This is an intricate bit of code that formats the results of this really messed up SQL query into a dictionary
+  # of table names and their corresponding row counts.
+  # Source of query: https://stackoverflow.com/a/42121447/3950780
+  def table_row_pairs
+    raw_row_counts = ActiveRecord::Base.connection.tables.map { |t| {t=>
+                  ActiveRecord::Base.connection.execute("select count(*) from #{t}")[0]} }
+    sanitized_row_counts = Hash.new
+    raw_row_counts.each do |table_row_dict|
+      table_row_hash = table_row_dict.first
+      table_name = table_row_hash[0]
+      row_count = table_row_hash[1]["count"]
+      sanitized_row_counts[table_name] = row_count
+    end
+    sanitized_row_counts
+  end
+  helper_method :table_row_pairs
+
+  def admin_jobs_list
+
+  end
+
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,7 +1,7 @@
 class AdminController < ApplicationController
 
   def dashboard
-    authorize! :dashboard, :admin
+    authorize! :manage, :all
   end
 
   # This is an intricate bit of code that formats the results of this really messed up SQL query into a dictionary

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,7 +1,7 @@
 class AdminController < ApplicationController
 
-  def resource_dashboard
-    authorize! :resource_dashboard, :admin
+  def dashboard
+    authorize! :dashboard, :admin
   end
 
   # This is an intricate bit of code that formats the results of this really messed up SQL query into a dictionary
@@ -10,20 +10,30 @@ class AdminController < ApplicationController
   def table_row_pairs
     raw_row_counts = ActiveRecord::Base.connection.tables.map { |t| {t=>
                   ActiveRecord::Base.connection.execute("select count(*) from #{t}")[0]} }
+    total_rows_in_db = 0
     sanitized_row_counts = Hash.new
     raw_row_counts.each do |table_row_dict|
       table_row_hash = table_row_dict.first
       table_name = table_row_hash[0]
       row_count = table_row_hash[1]["count"]
       sanitized_row_counts[table_name] = row_count
+      total_rows_in_db += row_count
     end
+    sanitized_row_counts["Total"] = total_rows_in_db
     sanitized_row_counts
   end
   helper_method :table_row_pairs
 
-  def admin_jobs_list
-    [TestJob]
+  def admin_job_list
+    [PurgeCompletedJobsJob, PurgeUnusedUsersJob]
   end
-  helper_method :admin_jobs_list
+  helper_method :admin_job_list
+
+  def run_admin_job
+    job_name = params[:job_name]
+    job = admin_job_list.find { |job| job.job_short_name == job_name }
+    job.perform_async
+    redirect_to admin_dashboard_path
+  end
 
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -22,7 +22,8 @@ class AdminController < ApplicationController
   helper_method :table_row_pairs
 
   def admin_jobs_list
-
+    [TestJob]
   end
+  helper_method :admin_jobs_list
 
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -113,23 +113,16 @@ class CoursesController < ApplicationController
 
   def run_course_job
     job_name = params[:job_name]
-    job = jobs_list.find { |job| job.job_short_name == job_name }
+    job = course_job_list.find { |job| job.job_short_name == job_name }
     job.perform_async(params[:course_id].to_i)
     redirect_to course_jobs_path
   end
 
-  # The list of jobs to make available to run on the jobs page.
-  @@course_jobs = [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob]
-
-  def jobs_list
-    @@course_jobs
+  # List of course jobs to make available to run
+  def course_job_list
+    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob]
   end
-  helper_method :jobs_list
-
-  def last_ten_jobs
-    CompletedJob.where(course_id: @course.id).reverse_order.limit(10)
-  end
-  helper_method :last_ten_jobs
+  helper_method :course_job_list
 
   private
     # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,6 +4,7 @@ class CoursesController < ApplicationController
   before_action :set_course, only: [:show, :edit, :update, :destroy]
   load_and_authorize_resource
 
+
   # GET /courses
   # GET /courses.json
   def index
@@ -113,12 +114,15 @@ class CoursesController < ApplicationController
   def run_course_job
     job_name = params[:job_name]
     job = jobs_list.find { |job| job.job_short_name == job_name }
-    job.perform_async(params[:course_id])
+    job.perform_async(params[:course_id].to_i)
     redirect_to course_jobs_path
   end
 
+  # The list of jobs to make available to run on the jobs page.
+  @@course_jobs = [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob]
+
   def jobs_list
-    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob]
+    @@course_jobs
   end
   helper_method :jobs_list
 

--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -1,4 +1,10 @@
 class AdminJob < BackgroundJob
+  @confirmation_dialog = "Are you sure you want to run this job?"
+
+  def self.confirmation_dialog
+    @confirmation_dialog
+  end
+
   def perform
     create_in_progress_job_record
   end

--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -1,0 +1,2 @@
+class AdminJob < BackgroundJob
+end

--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -1,2 +1,5 @@
 class AdminJob < BackgroundJob
+  def perform
+    create_in_progress_job_record
+  end
 end

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -1,0 +1,46 @@
+# BackgroundJob is the superclass of all SuckerPunch job routines run in this app.
+# It contains several methods and variables useful to all jobs
+
+class BackgroundJob
+  include SuckerPunch::Job
+
+  # Job name: display name of job
+  # Job short name: internal job name. Do not change this, it will break the job history
+  @job_name
+  @job_short_name
+  @job_record
+
+  def self.job_name
+    @job_name
+  end
+
+  def self.job_short_name
+    @job_short_name
+  end
+
+  def self.last_run
+    if CompletedJob.where(job_short_name: @job_short_name).last.nil?
+      return "N/A"
+    end
+    CompletedJob.where(job_short_name: @job_short_name).last.created_at
+  end
+
+  def create_in_progress_job_record
+    job_record = CompletedJob.new
+    job_record.job_name = self.class.job_name
+    job_record.job_short_name = self.class.job_short_name
+    job_record.summary = "In progress"
+    job_record.save
+    @job_record = job_record
+  end
+
+  def update_job_record_with_completion_summary(summary)
+    job_record = @job_record
+    job_record.summary = summary
+    job_record.save
+  end
+
+  def perform
+
+  end
+end

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -1,42 +1,21 @@
 require 'Octokit_Wrapper'
 
-class CourseJob
-  include SuckerPunch::Job
+class CourseJob < BackgroundJob
 
-  # Job name: display name of job
-  # Job short name: internal job name. Do not change this, it will break the job history
-  @job_name
-  @job_short_name
-
-  def self.job_name
-    @job_name
-  end
-
-  def self.job_short_name
-    @job_short_name
-  end
-
-  def self.last_run
-    if CompletedJob.where(job_short_name: @job_short_name).last.nil?
-      return "N/A"
-    end
-    CompletedJob.where(job_short_name: @job_short_name).last.created_at
+  def create_in_progress_job_record(course_id)
+    # This is a horrifying way to call the superclass method create_in_progress_job_record(),
+    # but it would seem this is the only way to call an overloaded parent method in Ruby. Strange design.
+    # Source: https://stackoverflow.com/a/8616695/3950780
+    BackgroundJob.instance_method(:create_in_progress_job_record).bind(self).call
+    @job_record.course_id = course_id
+    @job_record.save
   end
 
   def github_machine_user
     Octokit_Wrapper::Octokit_Wrapper.machine_user
   end
 
-  def create_completed_job_record(summary, course_id)
-    job_record = CompletedJob.new
-    job_record.job_name = self.class.job_name
-    job_record.job_short_name = self.class.job_short_name
-    job_record.summary = summary
-    job_record.course_id = course_id.to_i
-    job_record.save
-  end
-
   def perform(course_id)
-
+    create_in_progress_job_record(course_id)
   end
 end

--- a/app/jobs/purge_completed_jobs_job.rb
+++ b/app/jobs/purge_completed_jobs_job.rb
@@ -1,0 +1,13 @@
+class PurgeCompletedJobsJob < AdminJob
+
+  @job_name = "Purge All Completed Job Records"
+  @job_short_name = "purge_completed_jobs"
+  @confirmation_dialog = "Are you sure you want to delete all records of completed jobs?"
+
+  def perform
+    ActiveRecord::Base.connection_pool.with_connection do
+      super
+      CompletedJob.destroy_all
+    end
+  end
+end

--- a/app/jobs/purge_unused_users_job.rb
+++ b/app/jobs/purge_unused_users_job.rb
@@ -10,7 +10,7 @@ class PurgeUnusedUsersJob < AdminJob
       users = User.all
       users.each do |user|
         if user.roster_students.size == 0
-          unless is_instructor_or_admin(user)
+          unless instructor_or_admin?(user)
             user.destroy
             num_removed += 1
           end
@@ -24,7 +24,7 @@ class PurgeUnusedUsersJob < AdminJob
   # Slightly hacky way to tell whether user is an instructor as the user.has_role function
   # requires a specific course to correctly tell whether a user has an instructor role.
   # We want to know if the user is an instructor for ANY course.
-  def is_instructor_or_admin(user)
+  def instructor_or_admin?(user)
     user.roles.each { |role| return true if role.name == "admin" || role.name == "instructor" }
     false
   end

--- a/app/jobs/purge_unused_users_job.rb
+++ b/app/jobs/purge_unused_users_job.rb
@@ -6,7 +6,6 @@ class PurgeUnusedUsersJob < AdminJob
   def perform
     ActiveRecord::Base.connection_pool.with_connection do
       super
-      binding.pry
       num_removed = 0
       users = User.all
       users.each do |user|

--- a/app/jobs/purge_unused_users_job.rb
+++ b/app/jobs/purge_unused_users_job.rb
@@ -1,0 +1,29 @@
+class PurgeUnusedUsersJob < AdminJob
+  @job_name = "Purge Unenrolled Student Users"
+  @job_short_name = "purge_unenrolled_users"
+
+  def perform
+    super
+    num_removed = 0
+    users = User.all
+    users.each do |user|
+      if user.roster_students.size == 0
+        unless is_instructor_or_admin(user)
+          user.destroy
+          num_removed += 1
+        end
+      end
+    end
+    summary = num_removed.to_s + " users purged from the database."
+    update_job_record_with_completion_summary(summary)
+  end
+
+  # Slightly hacky way to tell whether user is an instructor as the user.has_role function
+  # requires a specific course to correctly tell whether a user has an instructor role.
+  # We want to know if the user is an instructor for ANY course.
+  def is_instructor_or_admin(user)
+    user.roles.each { |role| return true if role.name == "admin" || role.name == "instructor" }
+    false
+  end
+
+end

--- a/app/jobs/purge_unused_users_job.rb
+++ b/app/jobs/purge_unused_users_job.rb
@@ -1,21 +1,25 @@
 class PurgeUnusedUsersJob < AdminJob
   @job_name = "Purge Unenrolled Student Users"
   @job_short_name = "purge_unenrolled_users"
+  @confirmation_dialog = "Are you sure you want to delete all non-admin/instructor users not enrolled in a course?"
 
   def perform
-    super
-    num_removed = 0
-    users = User.all
-    users.each do |user|
-      if user.roster_students.size == 0
-        unless is_instructor_or_admin(user)
-          user.destroy
-          num_removed += 1
+    ActiveRecord::Base.connection_pool.with_connection do
+      super
+      binding.pry
+      num_removed = 0
+      users = User.all
+      users.each do |user|
+        if user.roster_students.size == 0
+          unless is_instructor_or_admin(user)
+            user.destroy
+            num_removed += 1
+          end
         end
       end
+      summary = num_removed.to_s + " users purged from the database."
+      update_job_record_with_completion_summary(summary)
     end
-    summary = num_removed.to_s + " users purged from the database."
-    update_job_record_with_completion_summary(summary)
   end
 
   # Slightly hacky way to tell whether user is an instructor as the user.has_role function

--- a/app/jobs/refresh_github_repos_job.rb
+++ b/app/jobs/refresh_github_repos_job.rb
@@ -5,6 +5,7 @@ class RefreshGithubReposJob < CourseJob
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do
+      super
       course = Course.find(course_id)
       org_repos = github_machine_user.organization_repositories(course.course_organization)
       students = course.roster_students
@@ -18,7 +19,7 @@ class RefreshGithubReposJob < CourseJob
         end
         summary = num_created.to_s + " repos created, " + (org_repos.size - num_created).to_s + " repos refreshed."
       end
-      create_completed_job_record(summary, course_id)
+      update_job_record_with_completion_summary(summary)
     end
   end
 

--- a/app/jobs/students_org_membership_check_job.rb
+++ b/app/jobs/students_org_membership_check_job.rb
@@ -5,7 +5,8 @@ class StudentsOrgMembershipCheckJob < CourseJob
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do
-      course = Course.find(course_id.to_i)
+      super
+      course = Course.find(course_id)
       org_member_ids = github_machine_user.organization_members(course.course_organization).map { |member| member.id }
       summary = ""
       unless org_member_ids.respond_to? :each
@@ -25,7 +26,7 @@ class StudentsOrgMembershipCheckJob < CourseJob
         end
         summary = num_changed.to_s + " org membership statuses updated"
       end
-      create_completed_job_record(summary, course_id)
+      update_job_record_with_completion_summary(summary)
     end
   end
 

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -5,7 +5,8 @@ class TestJob < CourseJob
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do
-      create_completed_job_record("Test completed.", course_id)
+      super
+      update_job_record_with_completion_summary("Test completed.")
     end
   end
 end

--- a/app/models/completed_job.rb
+++ b/app/models/completed_job.rb
@@ -7,7 +7,7 @@ include ActionView::Helpers::DateHelper
 
 class CompletedJob < ApplicationRecord
   def time_elapsed
-    return distance_of_time_in_words(created_at, DateTime.now, include_seconds: true) if summary == "In progress"
+    return distance_of_time_in_words_to_now(created_at, include_seconds: true) if summary == "In progress"
     distance_of_time_in_words(created_at, updated_at, include_seconds: true)
   end
 

--- a/app/models/completed_job.rb
+++ b/app/models/completed_job.rb
@@ -1,5 +1,14 @@
 # CompletedJob is no longer an accurate name for this model as the table now stores in-progress jobs as well.
 # It has not been renamed yet to avoid associated headaches.
 
+# Adds distance_of_time_in_words method
+require 'action_view'
+include ActionView::Helpers::DateHelper
+
 class CompletedJob < ApplicationRecord
+  def time_elapsed
+    return distance_of_time_in_words(created_at, DateTime.now, include_seconds: true) if summary == "In progress"
+    distance_of_time_in_words(created_at, updated_at, include_seconds: true)
+  end
+
 end

--- a/app/models/completed_job.rb
+++ b/app/models/completed_job.rb
@@ -1,2 +1,5 @@
+# CompletedJob is no longer an accurate name for this model as the table now stores in-progress jobs as well.
+# It has not been renamed yet to avoid associated headaches.
+
 class CompletedJob < ApplicationRecord
 end

--- a/app/models/completed_job.rb
+++ b/app/models/completed_job.rb
@@ -6,9 +6,14 @@ require 'action_view'
 include ActionView::Helpers::DateHelper
 
 class CompletedJob < ApplicationRecord
+
   def time_elapsed
     return distance_of_time_in_words_to_now(created_at, include_seconds: true) if summary == "In progress"
     distance_of_time_in_words(created_at, updated_at, include_seconds: true)
+  end
+
+  def self.last_ten_jobs(course_id)
+    CompletedJob.where(course_id: course_id).reverse_order.limit(10)
   end
 
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,7 @@ class Course < ApplicationRecord
   validates :course_organization, presence: true, length: {minimum: 3}, uniqueness: true
   validate :check_course_org_exists
   has_many :roster_students, dependent: :destroy
+  has_many :completed_jobs, dependent: :destroy
 
   resourcify
 

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -41,11 +41,12 @@
       </tr>
       </thead>
       <tbody>
-      <% admin_jobs_list.each do |job| %>
+      <% admin_job_list.each do |job| %>
         <tr>
           <td><%= job.job_name %></td>
           <td><%= job.last_run %></td>
-          <td></td>
+          <td><%= link_to 'Run Job', admin_run_admin_job_path(job_name: job.job_short_name),
+                          method: :post, data: { confirm: job.confirmation_dialog } %></td>
         </tr>
       <% end %>
       </tbody>
@@ -64,11 +65,21 @@
       <thead>
       <tr>
         <th>Job Name</th>
-        <th>Date Completed</th>
+        <th>Date Run</th>
+        <th>Time Elapsed</th>
         <th>Summary</th>
       </tr>
       </thead>
       <tbody>
+      <!--   Display last 10 completed jobs   -->
+      <% CompletedJob.last_ten_jobs(nil).each do |completed_job| %>
+        <tr>
+          <td><%= completed_job.job_name %></td>
+          <td><%= completed_job.created_at %></td>
+          <td><%= completed_job.time_elapsed %></td>
+          <td><%= completed_job.summary %></td>
+        </tr>
+      <% end %>
       </tbody>
     </table>
 

--- a/app/views/admin/resource_dashboard.html.erb
+++ b/app/views/admin/resource_dashboard.html.erb
@@ -1,0 +1,76 @@
+<h1> Resource Dashboard </h1>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Database Tables</h3>
+  </div>
+  <div class="panel-body">
+
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Table Name</th>
+        <th>Rows</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% table_row_pairs.each do |table_name, num_rows| %>
+        <tr>
+          <td><%= table_name %></td>
+          <td><%= num_rows %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Jobs</h3>
+  </div>
+  <div class="panel-body">
+
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Job Name</th>
+        <th>Last Run</th>
+        <th colspan="1"></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% admin_jobs_list.each do |job| %>
+        <tr>
+          <td><%= job.job_name %></td>
+          <td><%= job.last_run %></td>
+          <td></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Job Log</h3>
+  </div>
+  <div class="panel-body">
+
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Job Name</th>
+        <th>Date Completed</th>
+        <th>Summary</th>
+      </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+
+  </div>
+</div>

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -31,7 +31,7 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">Completed Job Log</h3>
+    <h3 class="panel-title">Job Log</h3>
   </div>
   <div class="panel-body">
 
@@ -39,7 +39,8 @@
       <thead>
       <tr>
         <th>Job Name</th>
-        <th>Date Completed</th>
+        <th>Date Run</th>
+        <th>Time Elapsed</th>
         <th>Summary</th>
       </tr>
       </thead>
@@ -49,6 +50,7 @@
         <tr>
           <td><%= completed_job.job_name %></td>
           <td><%= completed_job.created_at %></td>
+          <td><%= completed_job.time_elapsed %></td>
           <td><%= completed_job.summary %></td>
         </tr>
       <% end %>

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -15,7 +15,7 @@
       </tr>
       </thead>
       <tbody>
-      <% jobs_list.each do |job| %>
+      <% course_job_list.each do |job| %>
         <tr>
           <td><%= job.job_name %></td>
           <td><%= job.last_run %></td>
@@ -46,7 +46,7 @@
       </thead>
       <tbody>
       <!--   Display last 10 completed jobs   -->
-      <% last_ten_jobs.each do |completed_job| %>
+      <% CompletedJob.last_ten_jobs(@course.id).each do |completed_job| %>
         <tr>
           <td><%= completed_job.job_name %></td>
           <td><%= completed_job.created_at %></td>

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -6,3 +6,7 @@
 <% if can? :update, User %>
 	<li><%= nav_link 'Users', users_path %></li>
 <% end %>
+
+<% if can? :manage, :all %>
+  <li><%= nav_link "Admin", admin_dashboard_path %></li>
+<% end %>

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -4,6 +4,7 @@
   <% if current_user.has_role? :admin %>
     <h1> Welcome Admin </h1>
     <p> Proceed to the courses page to manage classes or to the users page to manage users </p>
+    <p><%= link_to "Admin Dashboard", admin_dashboard_path %></p>
   <p>Note: You can manage a class with a blue name</p>
     
   <% elsif current_user.has_role? :instructor %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
 
   resources :users
 
+  match 'admin/resource_dashboard' => 'admin#resource_dashboard', :via => :get
+
   # home page routes
   resources :visitors # NOTE that this defines a number of unused routes that would be good to remove for security
   root :to => "visitors#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,9 @@ Rails.application.routes.draw do
 
   resources :users
 
-  match 'admin/resource_dashboard' => 'admin#resource_dashboard', :via => :get
+  # Admin management dashboard
+  match 'admin/dashboard' => 'admin#dashboard', :via => :get
+  match 'admin/run_admin_job' => 'admin#run_admin_job', :via => :post
 
   # home page routes
   resources :visitors # NOTE that this defines a number of unused routes that would be good to remove for security


### PR DESCRIPTION
Apologies for another huge PR, it was necessary to change everything at once in order to implement all the functionality.

This PR implements/does the following things:
* It creates an admin dashboard for db resource management at the path admin/dashboard. It includes a table that lists each table of the db and how many rows that table uses (plus a total row count). This closes #109
* In this dashboard is also a job menu, for "admin jobs". Currently, there are two admin jobs: purge unused users (as described in #111) and purge all completed job records (for all courses + admin jobs).
* To implement these admin jobs, this PR creates a new superclass for asynchronous jobs in this project: BackgroundJob. Two classes inherit directly from BackgroundJob: CourseJob and AdminJob. CourseJob acts exactly as it does before. AdminJob is new, and is the superclass of all current and future admin-specific jobs. Right now, the only job functionality specific to AdminJobs is that it includes a confirmation dialog to run the job as these jobs involve data destruction.
* Completed job logs are now just job logs and include in-progress jobs. In addition, a new time-elapsed field is added to the job logs which shows the time in words between being run and completion for jobs or time between being run and the current time if the job is still in progress. This closes #111.
* Various bug fixes associated with jobs including one that ensures job records associated with a course are deleted when the course is deleted.