### PR TITLE
Added rate limit table to admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,6 @@ gem "actionview", ">= 5.1.6.2"
 
 gem 'omniauth-rails_csrf_protection', '~> 0.1'
 gem 'sucker_punch'
+
+# More accurate distance_of_time_in_words method
+gem 'dotiw'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
+    dotiw (4.0.1)
+      actionpack (>= 4)
+      i18n
     erubi (1.8.0)
     execjs (2.7.0)
     faraday (0.12.2)
@@ -287,6 +290,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   dotenv-rails
+  dotiw
   font-awesome-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,39 +1,64 @@
+require 'Octokit_Wrapper'
+require 'action_view'
+include ActionView::Helpers::DateHelper
+
 class AdminController < ApplicationController
 
-  def dashboard
-    authorize! :manage, :all
-  end
-
-  # This is an intricate bit of code that formats the results of this really messed up SQL query into a dictionary
-  # of table names and their corresponding row counts.
-  # Source of query: https://stackoverflow.com/a/42121447/3950780
-  def table_row_pairs
-    raw_row_counts = ActiveRecord::Base.connection.tables.map { |t| {t=>
-                  ActiveRecord::Base.connection.execute("select count(*) from #{t}")[0]} }
-    total_rows_in_db = 0
-    sanitized_row_counts = Hash.new
-    raw_row_counts.each do |table_row_dict|
-      table_row_hash = table_row_dict.first
-      table_name = table_row_hash[0]
-      row_count = table_row_hash[1]["count"]
-      sanitized_row_counts[table_name] = row_count
-      total_rows_in_db += row_count
+    def dashboard
+      authorize! :manage, :all
     end
-    sanitized_row_counts["Total"] = total_rows_in_db
-    sanitized_row_counts
-  end
-  helper_method :table_row_pairs
 
-  def admin_job_list
-    [PurgeCompletedJobsJob, PurgeUnusedUsersJob]
-  end
-  helper_method :admin_job_list
+    # This is an intricate bit of code that formats the results of this really messed up SQL query into a dictionary
+    # of table names and their corresponding row counts.
+    # Source of query: https://stackoverflow.com/a/42121447/3950780
+    def table_row_pairs
+      raw_row_counts = ActiveRecord::Base.connection.tables.map { |t| {t=>
+                    ActiveRecord::Base.connection.execute("select count(*) from #{t}")[0]} }
+      total_rows_in_db = 0
+      sanitized_row_counts = Hash.new
+      raw_row_counts.each do |table_row_dict|
+        table_row_hash = table_row_dict.first
+        table_name = table_row_hash[0]
+        row_count = table_row_hash[1]["count"]
+        sanitized_row_counts[table_name] = row_count
+        total_rows_in_db += row_count
+      end
+      sanitized_row_counts["Total"] = total_rows_in_db
+      sanitized_row_counts
+    end
+    helper_method :table_row_pairs
 
-  def run_admin_job
-    job_name = params[:job_name]
-    job = admin_job_list.find { |job| job.job_short_name == job_name }
-    job.perform_async
-    redirect_to admin_dashboard_path
-  end
+    def admin_job_list
+      [PurgeCompletedJobsJob, PurgeUnusedUsersJob]
+    end
+    helper_method :admin_job_list
 
+    def run_admin_job
+      job_name = params[:job_name]
+      job = admin_job_list.find { |job| job.job_short_name == job_name }
+      job.perform_async
+      redirect_to admin_dashboard_path
+    end
+
+    def rate_limits
+      rate_limits = Hash.new
+      rate_limits["GitHub API"] = github_rate_limit
+      rate_limits
+    end
+    helper_method :rate_limits
+
+  private
+    def github_rate_limit
+      limit_response = machine_user.rate_limit
+      unless limit_response.limit.nil?
+        reset_time = Time.at(limit_response.resets_at)
+        return {"remaining": limit_response.remaining, "limit": limit_response.limit, "reset": reset_time,
+                "until_reset": distance_of_time_in_words_to_now(reset_time)}
+      end
+      {"error": "Rate limit API request failed. Try refreshing the page."}
+    end
+
+    def machine_user
+      Octokit_Wrapper::Octokit_Wrapper.machine_user
+    end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -53,7 +53,8 @@ class AdminController < ApplicationController
       unless limit_response.limit.nil?
         reset_time = Time.at(limit_response.resets_at)
         return {"remaining": limit_response.remaining, "limit": limit_response.limit, "reset": reset_time,
-                "until_reset": distance_of_time_in_words_to_now(reset_time)}
+                "until_reset": distance_of_time_in_words_to_now(reset_time), "info": "GitHub Machine User: " +
+                ENV['MACHINE_USER_NAME']}
       end
       {"error": "Rate limit API request failed. Try refreshing the page."}
     end

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -28,6 +28,36 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
+    <h3 class="panel-title">API Rate Limits</h3>
+  </div>
+  <div class="panel-body">
+
+    <table class="table">
+      <thead>
+      <tr>
+        <th>API</th>
+        <th>Remaining</th>
+        <th>Limit</th>
+        <th>Time Until Reset</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% rate_limits.each do |rate_key, rate_value| %>
+        <tr>
+          <td><%= rate_key %></td>
+          <td><%= rate_value[:remaining] %></td>
+          <td><%= rate_value[:limit] %></td>
+          <td><%= rate_value[:until_reset] %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
     <h3 class="panel-title">Jobs</h3>
   </div>
   <div class="panel-body">

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -43,13 +43,13 @@
       </tr>
       </thead>
       <tbody>
-      <% rate_limits.each do |rate_key, rate_value| %>
+      <% rate_limits.each do |api_name, rate_limit_info| %>
         <tr>
-          <td><%= rate_key %></td>
-          <td><%= rate_value[:remaining] %></td>
-          <td><%= rate_value[:limit] %></td>
-          <td><%= rate_value[:until_reset] %></td>
-          <td><%= rate_value[:info] %></td>
+          <td><%= api_name %></td>
+          <td><%= rate_limit_info[:remaining] %></td>
+          <td><%= rate_limit_info[:limit] %></td>
+          <td><%= rate_limit_info[:until_reset] %></td>
+          <td><%= rate_limit_info[:info] %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -39,6 +39,7 @@
         <th>Remaining</th>
         <th>Limit</th>
         <th>Time Until Reset</th>
+        <th>Info</th>
       </tr>
       </thead>
       <tbody>
@@ -48,6 +49,7 @@
           <td><%= rate_value[:remaining] %></td>
           <td><%= rate_value[:limit] %></td>
           <td><%= rate_value[:until_reset] %></td>
+          <td><%= rate_value[:info] %></td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
This PR adds a rate limit table to the admin dashboard so administrators can see when the app has reached its GitHub API (and perhaps others in the future) limit or is getting close to it. The table looks like this: 
<img width="1046" alt="Screen Shot 2020-01-07 at 10 51 53 AM" src="https://user-images.githubusercontent.com/34611522/71921343-86a5cb80-313d-11ea-84b1-c6984cff1743.png">
This closes #122.
