### PR TITLE
Added permission levels to jobs and added check in course job menu

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -114,8 +114,12 @@ class CoursesController < ApplicationController
   def run_course_job
     job_name = params[:job_name]
     job = course_job_list.find { |job| job.job_short_name == job_name }
+    # This is a hack. It should be replaced as soon as possible, hopefully after authorization in the app is redone.
+    if job.permission_level == "admin" && !user.has_role?("admin")
+      redirect_to course_jobs_path, alert: "You do not have permission to run this job. Ask an admin to run it for you."
+    end
     job.perform_async(params[:course_id].to_i)
-    redirect_to course_jobs_path
+    redirect_to course_jobs_path, notice: "Job successfully queued."
   end
 
   # List of course jobs to make available to run

--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -1,6 +1,7 @@
 class AdminJob < BackgroundJob
   @confirmation_dialog = "Are you sure you want to run this job?"
   @job_description = "Admin Job"
+  @permission_level = "admin"
 
   def self.confirmation_dialog
     @confirmation_dialog

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -10,6 +10,7 @@ class BackgroundJob
   @job_short_name
   @job_record
   @job_description
+  @permission_level
 
   def self.job_name
     @job_name
@@ -28,6 +29,10 @@ class BackgroundJob
       return "N/A"
     end
     CompletedJob.where(job_short_name: @job_short_name).last.created_at
+  end
+
+  def self.permission_level
+    @permission_level
   end
 
   def create_in_progress_job_record

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -1,6 +1,7 @@
 require 'Octokit_Wrapper'
 
 class CourseJob < BackgroundJob
+  @permission_level = "instructor"
 
   @job_description = "Course Job"
 


### PR DESCRIPTION
This PR implements a ``permission_level`` variable for background jobs in the app. This doesn't currently change any functionality as default permissions will have the same behavior as before but it will allow job-specific permissions to be set e.g. RepoContributorJob can be set to admin only despite being a CourseJob. This PR closes #123.