### PR TITLE
Added hover text description to jobs on job run menus

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,15 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require_tree .
+
+$(document).ready(function(){
+    $('[data-toggle="tooltip"]').tooltip().on('shown.bs.tooltip', function(e) {
+        /**
+         * If the item that triggered the event has class 'large-tooltip'
+         * then also add it to the currently open tooltip
+         */
+        if ($(this).hasClass('large-tooltip')) {
+            $('body').find('.tooltip[role="tooltip"].show').addClass('large-tooltip');
+        }
+    })
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,14 @@
 @import "bootstrap";
 @import "bootstrap/theme";
 
+.tooltip-inner {
+  min-width: 300px; /* the minimum width */
+}
+
+.job_name {
+  border-bottom: 1px dotted black;
+}
+
 html, body {
   min-height: 100%;
   background-color: #eee;

--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -1,5 +1,6 @@
 class AdminJob < BackgroundJob
   @confirmation_dialog = "Are you sure you want to run this job?"
+  @job_description = "Admin Job"
 
   def self.confirmation_dialog
     @confirmation_dialog

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -9,6 +9,7 @@ class BackgroundJob
   @job_name
   @job_short_name
   @job_record
+  @job_description
 
   def self.job_name
     @job_name
@@ -16,6 +17,10 @@ class BackgroundJob
 
   def self.job_short_name
     @job_short_name
+  end
+
+  def self.job_description
+    @job_description
   end
 
   def self.last_run

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -2,6 +2,8 @@ require 'Octokit_Wrapper'
 
 class CourseJob < BackgroundJob
 
+  @job_description = "Course Job"
+
   def create_in_progress_job_record(course_id)
     # This is a horrifying way to call the superclass method create_in_progress_job_record(),
     # but it would seem this is the only way to call an overloaded parent method in Ruby. Strange design.

--- a/app/jobs/purge_completed_jobs_job.rb
+++ b/app/jobs/purge_completed_jobs_job.rb
@@ -3,6 +3,7 @@ class PurgeCompletedJobsJob < AdminJob
   @job_name = "Purge All Completed Job Records"
   @job_short_name = "purge_completed_jobs"
   @confirmation_dialog = "Are you sure you want to delete all records of completed jobs?"
+  @job_description = "Deletes all completed job records from the database."
 
   def perform
     ActiveRecord::Base.connection_pool.with_connection do

--- a/app/jobs/purge_course_repos_job.rb
+++ b/app/jobs/purge_course_repos_job.rb
@@ -1,7 +1,8 @@
 class PurgeCourseReposJob < CourseJob
 
-  @job_name = "Purge Course GitHub Repo Records From DB"
+  @job_name = "Purge Course GitHub Repo Records"
   @job_short_name = "purge_course_repos"
+  @job_description = "Removes all cached records of this course organization's GitHub repos from the database."
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do

--- a/app/jobs/purge_unused_users_job.rb
+++ b/app/jobs/purge_unused_users_job.rb
@@ -2,6 +2,7 @@ class PurgeUnusedUsersJob < AdminJob
   @job_name = "Purge Unenrolled Student Users"
   @job_short_name = "purge_unenrolled_users"
   @confirmation_dialog = "Are you sure you want to delete all non-admin/instructor users not enrolled in a course?"
+  @job_description = "Removes all users who are not instructors/admins that are not enrolled in any existing course."
 
   def perform
     ActiveRecord::Base.connection_pool.with_connection do

--- a/app/jobs/refresh_github_repos_job.rb
+++ b/app/jobs/refresh_github_repos_job.rb
@@ -1,7 +1,8 @@
 class RefreshGithubReposJob < CourseJob
 
-  @job_name = "Refresh Course GitHub Repository Records in DB"
+  @job_name = "Refresh Course GitHub Repository Records"
   @job_short_name = "refresh_course_repos"
+  @job_description = "Fetches all of the course org's repositories from GitHub and refreshes the cached records."
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do

--- a/app/jobs/students_org_membership_check_job.rb
+++ b/app/jobs/students_org_membership_check_job.rb
@@ -1,7 +1,8 @@
 class StudentsOrgMembershipCheckJob < CourseJob
 
-  @job_name = "Refresh Cached Student Org Membership Statuses"
+  @job_name = "Refresh Student Org Membership Statuses"
   @job_short_name = "refresh_org_membership"
+  @job_description = "Updates all students' cached GitHub org membership status in the database/"
 
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -3,6 +3,8 @@ class TestJob < CourseJob
   @job_name = "Test Job"
   @job_short_name = "test_job"
 
+  @job_description = "Adds a completed job record for this course for testing purposes."
+
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do
       super

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -43,7 +43,7 @@
       <tbody>
       <% admin_job_list.each do |job| %>
         <tr>
-          <td><%= job.job_name %></td>
+          <td><span class="job_name" data-toggle="tooltip" title = "<%= job.job_description %>"><%= job.job_name %></span></td>
           <td><%= job.last_run %></td>
           <td><%= link_to 'Run Job', admin_run_admin_job_path(job_name: job.job_short_name),
                           method: :post, data: { confirm: job.confirmation_dialog } %></td>

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -1,5 +1,20 @@
+<script>
+    $(document).ready(function(){
+        $('[data-toggle="tooltip"]').tooltip().on('shown.bs.tooltip', function(e) {
+            /**
+             * If the item that triggered the event has class 'large-tooltip'
+             * then also add it to the currently open tooltip
+             */
+            if ($(this).hasClass('large-tooltip')) {
+                $('body').find('.tooltip[role="tooltip"].show').addClass('large-tooltip');
+            }
+        })
+    });
+</script>
+
 <h1> <%= link_to @course.name, course_path(@course) %> </h1>
 
+<a href="#" data-toggle="tooltip" title="Hooray!">Hover over me</a>
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">Jobs</h3>
@@ -17,7 +32,7 @@
       <tbody>
       <% course_job_list.each do |job| %>
         <tr>
-          <td><%= job.job_name %></td>
+          <td><span class="job_name" data-toggle="tooltip" title = "<%= job.job_description %>"><%= job.job_name %></span></td>
           <td><%= job.last_run %></td>
           <td><%= link_to 'Run Job', course_run_course_job_path(@course, job_name: job.job_short_name),
                           method: :post %></td>

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -1,20 +1,5 @@
-<script>
-    $(document).ready(function(){
-        $('[data-toggle="tooltip"]').tooltip().on('shown.bs.tooltip', function(e) {
-            /**
-             * If the item that triggered the event has class 'large-tooltip'
-             * then also add it to the currently open tooltip
-             */
-            if ($(this).hasClass('large-tooltip')) {
-                $('body').find('.tooltip[role="tooltip"].show').addClass('large-tooltip');
-            }
-        })
-    });
-</script>
-
 <h1> <%= link_to @course.name, course_path(@course) %> </h1>
 
-<a href="#" data-toggle="tooltip" title="Hooray!">Hover over me</a>
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">Jobs</h3>


### PR DESCRIPTION
This PR implements hover text describing the specific actions of a job on the job run menu as described in #121. Screenshot of what it looks like below:
<img width="561" alt="Screen Shot 2020-01-14 at 2 15 52 PM" src="https://user-images.githubusercontent.com/34611522/72387583-b2dec080-36d8-11ea-91d2-c28b4744d172.png">
This closes #121.