### PR TITLE
Add GitHub membership and invitations link to admin show course page

### DIFF
--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -9,7 +9,9 @@
   of this course
 </p>
 <p>This course belongs to the github organization:
-  <%= link_to(@course.course_organization, "https://github.com/" + @course.course_organization)%>
+  <% course_org_link = "https://github.com/#{@course.course_organization}" %>
+  <%= link_to @course.course_organization, course_org_link %>.
+  See <%= link_to "Membership and Pending Invitations", "#{course_org_link}/people" %>
 </p>
 
 <%#= link_to "View Course Roster (#{@course.roster_students.length} enrolled)", course_roster_students_path(@course), class: "btn", role: "button" %>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -9,9 +9,9 @@
   of this course
 </p>
 <p>This course belongs to the github organization:
-  <% course_org_link = "https://github.com/#{@course.course_organization}" %>
+  <% course_org_link = "https://github.com/orgs/#{@course.course_organization}" %>
   <%= link_to @course.course_organization, course_org_link %>.
-  See <%= link_to "Membership and Pending Invitations", "#{course_org_link}/people" %>
+  See <%= link_to "Membership and Pending Invitations", "#{course_org_link}/people" %>.
 </p>
 
 <%#= link_to "View Course Roster (#{@course.roster_students.length} enrolled)", course_roster_students_path(@course), class: "btn", role: "button" %>


### PR DESCRIPTION
This PR simply implements the functionality described in #134:
>On the page
>https://ucsb-cs-github-linker.herokuapp.com/courses/:course_id
>right after the place where it says:
> This course belongs to the github organization: ucsb-cs56-w20
> Add a link that says:
> See Membership and Pending Invitations
> and have the text "Membership and Pending Invitations" link to, for example:
> https://github.com/orgs/ucsb-cs56-w20/people

Screenshot:
![image](https://user-images.githubusercontent.com/34611522/72388250-52e91980-36da-11ea-9f46-f5a0c8e06e94.png)
This closes #134.