### PR TITLE
Implemented bootstrap tables with many data table features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,4 @@ gem 'sucker_punch'
 # More accurate distance_of_time_in_words method
 gem 'dotiw'
 gem 'bootstrap-table-rails'
+gem 'jquery-turbolinks'

--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem 'sucker_punch'
 
 # More accurate distance_of_time_in_words method
 gem 'dotiw'
+gem 'bootstrap-table-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap-table-rails (1.13.4)
     builder (3.2.3)
     byebug (10.0.2)
     cancancan (2.1.3)
@@ -284,6 +285,7 @@ PLATFORMS
 DEPENDENCIES
   actionview (>= 5.1.6.2)
   bootstrap-sass (~> 3.4.1)
+  bootstrap-table-rails
   byebug
   cancancan (~> 2.0)
   capybara (~> 2.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -296,6 +299,7 @@ DEPENDENCIES
   font-awesome-rails
   jbuilder (~> 2.5)
   jquery-rails
+  jquery-turbolinks
   kaminari
   listen (>= 3.0.5, < 3.2)
   loofah (~> 2.3.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require jquery3
 //= require jquery_ujs
 //= require bootstrap-sprockets
+//= require bootstrap-table/bootstrap-table
 //= require_tree .
 
 $(document).ready(function(){

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,9 +11,9 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require turbolinks
 //= require jquery3
 //= require jquery_ujs
+//= require jquery.turbolinks
 //= require bootstrap-sprockets
 //= require bootstrap-table/bootstrap-table
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "bootstrap/theme";
+@import "bootstrap-table/bootstrap-table";
 
 .tooltip-inner {
   min-width: 300px; /* the minimum width */

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -93,11 +93,11 @@
   </div>
   <div class="panel-body">
 
-    <table class="table">
+    <table data-toggle="table">
       <thead>
       <tr>
-        <th>Job Name</th>
-        <th>Date Run</th>
+        <th data-sortable="true">Job Name</th>
+        <th data-sortable="true">Date Run</th>
         <th>Time Elapsed</th>
         <th>Summary</th>
       </tr>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -64,7 +64,8 @@
 <!--    </h4>-->
 
     <table class="bootstrap-table" data-toggle="table" data-search="true" data-show-export="true"
-            data-pagination="true" data-show-columns="true"  data-show-columns-toggle-all="true">
+            data-pagination="true" data-show-columns="true"  data-show-columns-toggle-all="true"
+            data-show-pagination-switch="true">
       <thead>
         <tr>
           <th>Perm</th>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -63,18 +63,21 @@
       <%# end %>
 <!--    </h4>-->
 
-    <table class="table">
+    <table class="bootstrap-table" data-toggle="table" data-search="true" data-show-export="true"
+            data-pagination="true" data-show-columns="true"  data-show-columns-toggle-all="true">
       <thead>
         <tr>
           <th>Perm</th>
-          <th>First name</th>
-          <th>Last name</th>
-          <th>Email</th>
-          <th>Enrolled</th>
-          <th>TA</th>
-          <th>Github ID</th>
-          <th>Org Membership</th>
-          <th colspan="3"></th>
+          <th data-sortable="true">First name</th>
+          <th data-sortable="true">Last name</th>
+          <th data-sortable="true">Email</th>
+          <th data-sortable="true">Enrolled</th>
+          <th data-sortable="true">TA</th>
+	  <th data-sortable="true">Github ID</th>
+          <th data-sortable="true">Org Membership</th>
+          <th></th>
+          <th></th>
+          <th></th>
         </tr>
       </thead>
 

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -93,7 +93,7 @@
             <td><%= !student.user.nil? and student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
             <% if !student.username.nil? and !student.username.empty? %>
               <td><a href="https://github.com/<%= student.username %>"><%= student.username %></td>
-              <td><%= student.is_org_member %></td>
+              <td><%= student.is_org_member ? "True" : "False" %></td>
             <% else %>
               <td></td>
               <td></td>

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -35,11 +35,11 @@
   </div>
   <div class="panel-body">
 
-    <table class="table">
+    <table data-toggle="table">
       <thead>
       <tr>
-        <th>Job Name</th>
-        <th>Date Run</th>
+        <th data-sortable="true">Job Name</th>
+        <th data-sortable="true">Date Run</th>
         <th>Time Elapsed</th>
         <th>Summary</th>
       </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,8 +20,8 @@
 <!--      </div>-->
     <%# table containing the course list %>
     <table class="bootstrap-table" data-toggle="table" data-search="true" data-show-export="true"
-           data-pagination="true" data-show-columns="true"  data-show-columns-toggle-all="true"
-           data-show-pagination-switch="true" id="course_list">
+           data-pagination="true" data-show-columns="true"
+           data-show-columns-toggle-all="true" data-show-pagination-switch="true" id="course_list">
       <thead>
         <tr>
           <th data-sortable="true">Name</th>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -19,15 +19,17 @@
 <!--        <input id="users_search" type="text" class="form-control" placeholder="Search..." onkeyup="filter_list_by_keyword()">-->
 <!--      </div>-->
     <%# table containing the course list %>
-    <table class="table table-sm" id="course_list">
+    <table class="bootstrap-table" data-toggle="table" data-search="true" data-show-export="true"
+           data-pagination="true" data-show-columns="true"  data-show-columns-toggle-all="true"
+           data-show-pagination-switch="true" id="course_list">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Username</th>
+          <th data-sortable="true">Name</th>
+          <th data-sortable="true">Username</th>
           <th>uid</th>
-          <th>Admin</th>
+          <th data-sortable="true">Admin</th>
           <th></th>
-          <th>Instructor</th>
+          <th data-sortable="true">Instructor</th>
           <th></th>
         </tr>
       </thead>
@@ -69,8 +71,8 @@
         <% end %>
       </tbody>
     </table>
-    <div><%= page_entries_info @users %></div>
-    <div><%= paginate @users, window: 5 %></div>
+<!--    <div><%#= page_entries_info @users %></div>-->
+<!--    <div><%#= paginate @users, window: 5 %></div>-->
   </div>
 </div>
 


### PR DESCRIPTION
This PR implements fancy tables using the bootstrap-table-rails gem. It updates job logs, the users list page, and the course index page that shows the list of students in the course. A fully-featured table in the app looks like this:

<img width="1249" alt="Screen Shot 2020-01-14 at 4 19 53 PM" src="https://user-images.githubusercontent.com/34611522/72394609-b62f7780-36eb-11ea-8952-99d4d3e1ed39.png">

We implement search, configurable and toggle-able pagination (client-side at the moment), sorting by a column's contents and only showing certain columns.

This closes #120 in a much more epic fashion.
