### PR TITLE
Refactored jobs to allow for proper exception handling and avoid code reuse

### DIFF
--- a/app/jobs/admin_job.rb
+++ b/app/jobs/admin_job.rb
@@ -6,7 +6,4 @@ class AdminJob < BackgroundJob
     @confirmation_dialog
   end
 
-  def perform
-    create_in_progress_job_record
-  end
 end

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -46,6 +46,24 @@ class BackgroundJob
   end
 
   def perform
+    ActiveRecord::Base.connection_pool.with_connection do
+      begin
+        create_in_progress_job_record
+        attempt_job
+      rescue Exception => e
+        rescue_job(e)
+      end
+    end
+  end
 
+  def attempt_job
+    # What a job actually does
+
+  end
+
+  def rescue_job(exception)
+    # Update job log record and reraise exception
+    update_job_record_with_completion_summary("An exception occurred. Please see the logs for more info.")
+    raise exception
   end
 end

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -18,6 +18,17 @@ class CourseJob < BackgroundJob
   end
 
   def perform(course_id)
-    create_in_progress_job_record(course_id)
+    ActiveRecord::Base.connection_pool.with_connection do
+      create_in_progress_job_record(course_id)
+      begin
+        attempt_job(course_id)
+      rescue Exception => e
+        rescue_job(e)
+      end
+    end
+  end
+
+  def attempt_job(course_id)
+
   end
 end

--- a/app/jobs/purge_completed_jobs_job.rb
+++ b/app/jobs/purge_completed_jobs_job.rb
@@ -5,10 +5,7 @@ class PurgeCompletedJobsJob < AdminJob
   @confirmation_dialog = "Are you sure you want to delete all records of completed jobs?"
   @job_description = "Deletes all completed job records from the database."
 
-  def perform
-    ActiveRecord::Base.connection_pool.with_connection do
-      super
-      CompletedJob.destroy_all
-    end
+  def attempt_job
+    CompletedJob.destroy_all
   end
 end

--- a/app/jobs/purge_course_repos_job.rb
+++ b/app/jobs/purge_course_repos_job.rb
@@ -4,13 +4,9 @@ class PurgeCourseReposJob < CourseJob
   @job_short_name = "purge_course_repos"
   @job_description = "Removes all cached records of this course organization's GitHub repos from the database."
 
-  def perform(course_id)
-    ActiveRecord::Base.connection_pool.with_connection do
-      super
-      destroyed_repos = GithubRepo.where(:course_id => course_id.to_i).destroy_all
-      summary = "Purged " + destroyed_repos.size.to_s + " records from the database."
-      update_job_record_with_completion_summary(summary)
-    end
+  def attempt_job(course_id)
+    destroyed_repos = GithubRepo.where(:course_id => course_id.to_i).destroy_all
+    summary = "Purged " + destroyed_repos.size.to_s + " records from the database."
+    update_job_record_with_completion_summary(summary)
   end
-
 end

--- a/app/jobs/refresh_github_repos_job.rb
+++ b/app/jobs/refresh_github_repos_job.rb
@@ -4,24 +4,22 @@ class RefreshGithubReposJob < CourseJob
   @job_short_name = "refresh_course_repos"
   @job_description = "Fetches all of the course org's repositories from GitHub and refreshes the cached records."
 
-  def perform(course_id)
-    ActiveRecord::Base.connection_pool.with_connection do
-      super
-      course = Course.find(course_id)
-      org_repos = github_machine_user.organization_repositories(course.course_organization)
-      students = course.roster_students
-      summary = ""
-      if org_repos.size == 0
-        summary = "Failed to fetch organization's repos. Either none exist or call to GitHub API failed."
-      else
-        num_created = 0
-        org_repos.each do |github_repo|
-          num_created += create_repo_record(github_repo, course, students)
-        end
-        summary = num_created.to_s + " repos created, " + (org_repos.size - num_created).to_s + " repos refreshed."
+  def attempt_job(course_id)
+    course = Course.find(course_id)
+    org_repos = github_machine_user.organization_repositories(course.course_organization)
+    students = course.roster_students
+    summary = ""
+    if org_repos.respond_to? :each
+      summary = "Failed to fetch organization's repos. Either none exist or call to GitHub API failed."
+    else
+      num_created = 0
+      org_repos.each do |github_repo|
+        num_created += create_repo_record(github_repo, course, students)
       end
-      update_job_record_with_completion_summary(summary)
+      summary = num_created.to_s + " repos created, " + (org_repos.size - num_created).to_s + " repos refreshed."
+      # RepoCollaboratorsJob.perform_async(course_id)
     end
+    update_job_record_with_completion_summary(summary)
   end
 
   def create_repo_record(github_repo, course, students)

--- a/app/jobs/students_org_membership_check_job.rb
+++ b/app/jobs/students_org_membership_check_job.rb
@@ -4,31 +4,28 @@ class StudentsOrgMembershipCheckJob < CourseJob
   @job_short_name = "refresh_org_membership"
   @job_description = "Updates all students' cached GitHub org membership status in the database/"
 
-  def perform(course_id)
-    ActiveRecord::Base.connection_pool.with_connection do
-      super
-      course = Course.find(course_id)
-      org_member_ids = github_machine_user.organization_members(course.course_organization).map { |member| member.id }
-      summary = ""
-      unless org_member_ids.respond_to? :each
-        summary = "Failed to fetch org members from GitHub."
-      else
-        roster_students = course.roster_students
-        num_changed = 0
-        roster_students.each do |student|
-          unless student.user.nil? or student.user.uid.nil?
-            is_org_member = org_member_ids.include?(student.user.uid.to_i)
-            if is_org_member != student.is_org_member
-              student.is_org_member = is_org_member
-              num_changed += 1
-              student.save
-            end
+  def attempt_job(course_id)
+    course = Course.find(course_id)
+    org_member_ids = github_machine_user.organization_members(course.course_organization).map { |member| member.id }
+    summary = ""
+    unless org_member_ids.respond_to? :each
+      summary = "Failed to fetch org members from GitHub."
+    else
+      roster_students = course.roster_students
+      num_changed = 0
+      roster_students.each do |student|
+        unless student.user.nil? or student.user.uid.nil?
+          is_org_member = org_member_ids.include?(student.user.uid.to_i)
+          if is_org_member != student.is_org_member
+            student.is_org_member = is_org_member
+            num_changed += 1
+            student.save
           end
         end
-        summary = num_changed.to_s + " org membership statuses updated"
       end
-      update_job_record_with_completion_summary(summary)
+      summary = num_changed.to_s + " org membership statuses updated"
     end
+    update_job_record_with_completion_summary(summary)
   end
 
 end

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -2,13 +2,9 @@ class TestJob < CourseJob
 
   @job_name = "Test Job"
   @job_short_name = "test_job"
-
   @job_description = "Adds a completed job record for this course for testing purposes."
 
-  def perform(course_id)
-    ActiveRecord::Base.connection_pool.with_connection do
-      super
-      update_job_record_with_completion_summary("Test completed.")
-    end
+  def attempt_job(course_id)
+    update_job_record_with_completion_summary("Test completed.")
   end
 end


### PR DESCRIPTION
This PR implements the refactor we talked about whereby exception handling and the connection pool are handled in the superclass ``Background Job``. The reference implementation is as follows (and found in the class):
```ruby
  def perform
    ActiveRecord::Base.connection_pool.with_connection do
      begin
        create_in_progress_job_record
        attempt_job
      rescue Exception => e
        rescue_job(e)
      end
    end
  end

  def attempt_job
    # What a job actually does

  end

  def rescue_job(exception)
    # Update job log record and reraise exception
    update_job_record_with_completion_summary("An exception occurred. Please see the logs for more info.")
    raise exception
  end
```

Where the ``attempt_job`` method is overridden by each job class to implement its functionality, and perform is no longer overridden except where necessary as in ``CourseJob`` to overload with the ``course_id`` parameter. If a job throws an exception, it will be caught by the default handling of updating the summary to reflect the fact that an exception occurred, effectively marking it complete in the job log.

This PR closes #127. In fact, I did create that issue back when I discovered the bug. 