### PR TITLE
Fixed critical issue causing refresh repo job to fail every time

### DIFF
--- a/app/jobs/refresh_github_repos_job.rb
+++ b/app/jobs/refresh_github_repos_job.rb
@@ -9,7 +9,7 @@ class RefreshGithubReposJob < CourseJob
     org_repos = github_machine_user.organization_repositories(course.course_organization)
     students = course.roster_students
     summary = ""
-    if org_repos.respond_to? :each
+    if !org_repos.respond_to? :each
       summary = "Failed to fetch organization's repos. Either none exist or call to GitHub API failed."
     else
       num_created = 0


### PR DESCRIPTION
This was caused by a typo in an if statement that was not inverted properly. The issue was inadvertently introduced two days ago while implementing the ``attempt_job`` method.  Merge ASAP as the change is small but important.