### PR TITLE
Implemented course repository regex search page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -69,6 +69,10 @@ main {
   font-size: 16px;
 }
 
+input.form-control {
+  margin-bottom: 10px;
+}
+
 // // make all images responsive by default
 // img {
 //   @extend .img-responsive;

--- a/app/controllers/courses/roster_students_controller.rb
+++ b/app/controllers/courses/roster_students_controller.rb
@@ -91,20 +91,6 @@ module Courses
     end
     helper_method :find_org_repos
 
-    def find_contributors(repo_id)
-      # This query gets certain information about a student, their user, and relationship to the repository in question.
-      # It is written in raw SQL because it would take several queries using Rails syntax.
-      query = <<-SQL
-        SELECT rs.first_name, rs.last_name, rs.id, u.username, rc.permission_level
-        FROM users u
-          JOIN roster_students rs ON (u.id = rs.user_id and #{@parent.id} = rs.course_id)
-          JOIN repo_contributors rc ON u.id = rc.user_id
-        WHERE #{repo_id} = rc.github_repo_id
-      SQL
-      ActiveRecord::Base.connection.exec_query(query)
-    end
-    helper_method :find_contributors
-
     private
       # Use callbacks to share common setup or constraints between actions.
       def set_roster_student

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -132,7 +132,7 @@ class CoursesController < ApplicationController
 
   def search_repos
     @course = Course.find(params[:course_id])
-    redirect_to course_repos_path(course_id: @course.id, params: {"search": params[:search]})
+    redirect_to course_repos_path(@course, search: params[:search])
   end
 
   private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -124,6 +124,17 @@ class CoursesController < ApplicationController
   end
   helper_method :course_job_list
 
+  def repo_search(regex)
+    query = <<-SQL
+      SELECT gr.name, gr.url, gr.visibility, u.username, rs.first_name, rs.last_name, rs.id, rc.permission_level
+      FROM github_repos gr
+        JOIN repo_contributors rc ON gr.id = rc.github_repo_id
+        JOIN users u ON u.id = rc.user_id
+        JOIN roster_students rs ON u.id = rs.user_id
+      WHERE gr.course_id = #{@course.id}
+    SQL
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_course

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -124,15 +124,15 @@ class CoursesController < ApplicationController
   end
   helper_method :course_job_list
 
-  def repo_search(regex)
-    query = <<-SQL
-      SELECT gr.name, gr.url, gr.visibility, u.username, rs.first_name, rs.last_name, rs.id, rc.permission_level
-      FROM github_repos gr
-        JOIN repo_contributors rc ON gr.id = rc.github_repo_id
-        JOIN users u ON u.id = rc.user_id
-        JOIN roster_students rs ON u.id = rs.user_id
-      WHERE gr.course_id = #{@course.id}
-    SQL
+  def repos
+    @course = Course.find(params[:course_id])
+    @repos = GithubRepo.where("name ~* ?", params[:search])
+    authorize! :repos, @course
+  end
+
+  def search_repos
+    @course = Course.find(params[:course_id])
+    redirect_to course_repos_path(course_id: @course.id, params: {"search": params[:search]})
   end
 
   private
@@ -143,7 +143,7 @@ class CoursesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def course_params
-      params.require(:course).permit(:name,:course_organization,:hidden)
+      params.require(:course).permit(:name,:course_organization,:hidden, :search)
     end
 
     def add_instructor(id)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -126,7 +126,7 @@ class CoursesController < ApplicationController
 
   def repos
     @course = Course.find(params[:course_id])
-    @repos = GithubRepo.where("name ~* ?", params[:search])
+    @repos = GithubRepo.where(course_id: params[:course_id]).where("name ~* ?", params[:search])
     authorize! :repos, @course
   end
 

--- a/app/jobs/refresh_github_repos_job.rb
+++ b/app/jobs/refresh_github_repos_job.rb
@@ -39,6 +39,7 @@ class RefreshGithubReposJob < CourseJob
     end
     repo_record.name = github_repo.name
     repo_record.full_name = github_repo.full_name  # full_name includes organization name e.g. test-org/test-repo
+    repo_record.visibility = github_repo.private ? "private" : "public"
     repo_record.url = github_repo.html_url
     repo_record.last_updated_at = github_repo.updated_at
     repo_record.save

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -2,4 +2,17 @@ class GithubRepo < ApplicationRecord
   belongs_to :course
   has_many :repo_contributors
   has_many :users, through: :repo_contributors
+
+  def find_contributors
+    # This query gets certain information about a student, their user, and relationship to the repository in question.
+    # It is written in raw SQL because it would take several queries using Rails syntax.
+    query = <<-SQL
+        SELECT rs.first_name, rs.last_name, rs.id, u.username, rc.permission_level
+        FROM users u
+          JOIN roster_students rs ON (u.id = rs.user_id and #{self.course_id} = rs.course_id)
+          JOIN repo_contributors rc ON u.id = rc.user_id
+        WHERE #{self.id} = rc.github_repo_id
+    SQL
+    ActiveRecord::Base.connection.exec_query(query)
+  end
 end

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -34,9 +34,10 @@
 
       <% end %>
       <%= link_to "View Jobs", course_jobs_path(@course), method: :get, class: "btn",
-                  style:
-          "display:inline-block; float: right; margin-left: 10px;" %>
+                  style: "display:inline-block; float: right; margin-left: 10px;" %>
       <%= link_to "Download Roster as CSV", course_roster_students_path(@course, :format => "csv"), method: :get, class: "btn", style: "display:inline-block; float: right; margin-left: 10px;" %>
+      <%= link_to "Course Repositories", course_repos_path(@course), method: :get, class: "btn",
+                  style: "display:inline-block; float: right; margin-left: 10px;" %>
       <% if can? :create, RosterStudent %>
         <%= link_to 'New Student', new_course_roster_student_path(@course), class: "btn", style: "display: inline-block; float: right; margin-left: 10px;" %>
       <% end %>

--- a/app/views/courses/repos.html.erb
+++ b/app/views/courses/repos.html.erb
@@ -1,4 +1,4 @@
-<h1>GitHub Repositories</h1>
+<h1>Course Repositories</h1>
 
 <%= form_tag course_search_repos_path, method: :get do %>
   <div class="input-group">

--- a/app/views/courses/repos.html.erb
+++ b/app/views/courses/repos.html.erb
@@ -1,7 +1,11 @@
 <h1>GitHub Repositories</h1>
 
 <%= form_tag course_search_repos_path, method: :get do %>
-  <%= text_field_tag :search, "", class: 'form-control', placeholder: "Regular Expression Search" %>
+  <div class="input-group">
+    <span class="input-group-addon" id="basic-addon1">(.*)</span>
+    <%= text_field_tag :search, (params[:search] or ""), class: 'form-control', placeholder: "Regular Expression Search" %>
+  </div>
+  <p></p>
   <%= submit_tag "Search", class: 'btn btn-primary' %>
 <% end %>
 

--- a/app/views/courses/repos.html.erb
+++ b/app/views/courses/repos.html.erb
@@ -1,0 +1,38 @@
+<h1>GitHub Repositories</h1>
+
+<%= form_tag course_search_repos_path, method: :get do %>
+  <%= text_field_tag :search, "", class: 'form-control', placeholder: "Regular Expression Search" %>
+  <%= submit_tag "Search", class: 'btn btn-primary' %>
+<% end %>
+
+<p></p>
+<% unless @repos.nil? %>
+  <% unless @repos.size == 0 %>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Repository (Student Name)</th>
+        <th>GitHub ID</th>
+        <th>Visibility (Permission Level)</th>
+      </tr>
+      </thead>
+      <% @repos.each do |repo| %>
+        <tr>
+          <td><a href=<%= repo.url %>><%= repo.name %></td>
+          <td></td>
+          <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
+        </tr>
+        <% [].each do |contributor| %>
+          <tr class="leftMargin">
+            <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
+                            course_roster_student_path(@parent, contributor["id"]) %></td>
+            <td><a href="https://github.com/<%= contributor["username"] %>"><%= contributor["username"] %></td>
+            <td><a href="<%= repo.url %>/settings/access"><%= contributor["permission_level"] %></td>
+          </tr>
+        <% end %>
+      <% end %>
+    </table>
+  <% else %>
+    <p>No results were found for your query.</p>
+  <% end %>
+<% end %>

--- a/app/views/courses/repos.html.erb
+++ b/app/views/courses/repos.html.erb
@@ -22,10 +22,10 @@
           <td></td>
           <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
         </tr>
-        <% [].each do |contributor| %>
+        <% repo.find_contributors.each do |contributor| %>
           <tr class="leftMargin">
             <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
-                            course_roster_student_path(@parent, contributor["id"]) %></td>
+                            course_roster_student_path(@course, contributor["id"]) %></td>
             <td><a href="https://github.com/<%= contributor["username"] %>"><%= contributor["username"] %></td>
             <td><a href="<%= repo.url %>/settings/access"><%= contributor["permission_level"] %></td>
           </tr>

--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -44,16 +44,16 @@
     <tr>
       <th>Repository (Student Name)</th>
       <th>GitHub ID</th>
-      <th>Permission Level</th>
+      <th>Visibility (Permission Level)</th>
     </tr>
     </thead>
     <% find_org_repos.each do |repo| %>
       <tr>
         <td><a href=<%= repo.url %>><%= repo.name %></td>
         <td></td>
-        <td></td>
+        <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
       </tr>
-      <% find_contributors(repo.id).each do |contributor| %>
+      <% repo.find_contributors.each do |contributor| %>
         <tr class="leftMargin">
           <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
                           course_roster_student_path(@parent, contributor["id"]) %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     post :join
     get :view_ta
     get :jobs
+    get :repos
+    get :search_repos
     post :run_course_job
     post :update_ta
     scope module: :courses do

--- a/db/migrate/20200201195311_add_visibility_to_github_repos.rb
+++ b/db/migrate/20200201195311_add_visibility_to_github_repos.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToGithubRepos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :github_repos, :visibility, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20200106180359) do
     t.datetime "updated_at", null: false
     t.integer "repo_id"
     t.string "full_name"
+    t.string "visibility"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
   end
 


### PR DESCRIPTION
Note: The branch this PR is based off of is literally branched from fs-RevertReversionOfContributorMatching (#145) and so should not be merged before that one. This PR is marked as a draft accordingly.

This PR implements the functionality described in #146, with the exception of team functionality:

> As an admin of a course organization, I can
> (a) Enter a regular expression
> (b) I will then get a list of repos that match that regular expression
> (c) That list will have links to each repo, but also columns for:
> (i) public vs. private
> (ii) list of collaborators on the repo (annotated with their level of access)
> (iii) list of teams that have access to the repo (annotated with their level of access)

The page looks like this:

<img width="1084" alt="Screen Shot 2020-02-01 at 9 23 46 PM" src="https://user-images.githubusercontent.com/34611522/73603569-2554fa80-4539-11ea-945e-1b80ab15ccc1.png">

It is very similar to the repository table on a student's page; instead, it allows regular expression searching and can show all repositories in a course org.