### PR TITLE
Made various UI tweaks and fixed typos

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require jquery.turbolinks
 //= require bootstrap-sprockets
 //= require bootstrap-table/bootstrap-table
+//= require bootstrap-table/extensions/filter-control/bootstrap-table-filter-control
 //= require_tree .
 
 $(document).ready(function(){

--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -74,7 +74,7 @@ $(document).ready(function () {
          // console.log(CSVToArray(reader.readAsText(selectedFile)));
  
      });
- 
+
  });
  
  // http://stackoverflow.com/questions/1293147/javascript-code-to-parse-csv-data

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,10 @@
 @import "bootstrap/theme";
 @import "bootstrap-table/bootstrap-table";
 
+.navbar-signin-btn {
+  padding-right: 25px;
+}
+
 .tooltip-inner {
   min-width: 300px; /* the minimum width */
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -74,7 +74,7 @@ main {
   font-size: 16px;
 }
 
-input.form-control {
+input.repo-search {
   margin-bottom: 10px;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import "bootstrap";
 @import "bootstrap/theme";
 @import "bootstrap-table/bootstrap-table";
+@import "bootstrap-table/extensions/filter-control/bootstrap-table-filter-control";
 
 .navbar-signin-btn {
   padding-right: 25px;

--- a/app/assets/stylesheets/courses.scss
+++ b/app/assets/stylesheets/courses.scss
@@ -6,3 +6,8 @@
   background-color:lightgray;
   font-weight: bold;
 }
+
+// Fixes most infuriating display bug of all time where select filters would be misaligned with input ones.
+select.form-control {
+  margin-bottom: 10px;
+}

--- a/app/assets/stylesheets/courses.scss
+++ b/app/assets/stylesheets/courses.scss
@@ -8,6 +8,7 @@
 }
 
 // Fixes most infuriating display bug of all time where select filters would be misaligned with input ones.
-select.form-control {
-  margin-bottom: 10px;
+
+div.filter-control {
+  padding-bottom: 2px;
 }

--- a/app/jobs/repo_collaborators_job.rb
+++ b/app/jobs/repo_collaborators_job.rb
@@ -1,7 +1,9 @@
 class RepoCollaboratorsJob < CourseJob
 
-  @job_name = "Get All Repository Collaborators"
+  @job_name = "Refresh All Repository Collaborators"
   @job_short_name = "get_repo_contributors"
+  @job_description = "Fetches a collaborator list for every repository in the organization and associates them with
+the corresponding students."
 
   def attempt_job(course_id)
     course = Course.find(course_id)

--- a/app/jobs/students_org_membership_check_job.rb
+++ b/app/jobs/students_org_membership_check_job.rb
@@ -2,7 +2,8 @@ class StudentsOrgMembershipCheckJob < CourseJob
 
   @job_name = "Refresh Student Org Membership Statuses"
   @job_short_name = "refresh_org_membership"
-  @job_description = "Updates all students' cached GitHub org membership status in the database/"
+  @job_description = "Fetches org members from GitHub and updates all students' cached org membership status in
+the database."
 
   def attempt_job(course_id)
     course = Course.find(course_id)

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -2,32 +2,6 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">Database Tables</h3>
-  </div>
-  <div class="panel-body">
-
-    <table class="table">
-      <thead>
-      <tr>
-        <th>Table Name</th>
-        <th>Rows</th>
-      </tr>
-      </thead>
-      <tbody>
-      <% table_row_pairs.each do |table_name, num_rows| %>
-        <tr>
-          <td><%= table_name %></td>
-          <td><%= num_rows %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
     <h3 class="panel-title">API Rate Limits</h3>
   </div>
   <div class="panel-body">
@@ -110,6 +84,32 @@
           <td><%= completed_job.created_at %></td>
           <td><%= completed_job.time_elapsed %></td>
           <td><%= completed_job.summary %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Database Tables</h3>
+  </div>
+  <div class="panel-body">
+
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Table Name</th>
+        <th>Rows</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% table_row_pairs.each do |table_name, num_rows| %>
+        <tr>
+          <td><%= table_name %></td>
+          <td><%= num_rows %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -66,17 +66,17 @@
 
     <table class="bootstrap-table" data-toggle="table" data-search="true" data-show-export="true"
             data-pagination="true" data-show-columns="true"  data-show-columns-toggle-all="true"
-            data-show-pagination-switch="true">
+            data-show-pagination-switch="true" data-filter-control="true">
       <thead>
         <tr>
-          <th data-sortable="true">Perm</th>
-          <th data-sortable="true">First name</th>
-          <th data-sortable="true">Last name</th>
-          <th data-sortable="true">Email</th>
-          <th data-sortable="true">Enrolled</th>
-          <th data-sortable="true">TA</th>
-	        <th data-sortable="true">Github ID</th>
-          <th data-sortable="true">Org Membership</th>
+          <th data-sortable="true" data-field="Perm" data-filter-control="input">Perm</th>
+          <th data-sortable="true" data-field="FirstName" data-filter-control="input">First name</th>
+          <th data-sortable="true" data-field="LastName" data-filter-control="input">Last name</th>
+          <th data-sortable="true" data-field="Email" data-filter-control="input">Email</th>
+          <th data-sortable="true" data-field="Enrolled" data-filter-control="select">Enrolled</th>
+          <th data-sortable="true" data-field="TA" data-filter-control="select">TA</th>
+	        <th data-sortable="true" data-field="GithubId" data-filter-control="input">Github ID</th>
+          <th data-sortable="true" data-field="OrgMembership" data-filter-control="select">Org Membership</th>
           <th></th>
           <th></th>
           <th></th>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -69,13 +69,13 @@
             data-show-pagination-switch="true">
       <thead>
         <tr>
-          <th>Perm</th>
+          <th data-sortable="true">Perm</th>
           <th data-sortable="true">First name</th>
           <th data-sortable="true">Last name</th>
           <th data-sortable="true">Email</th>
           <th data-sortable="true">Enrolled</th>
           <th data-sortable="true">TA</th>
-	  <th data-sortable="true">Github ID</th>
+	        <th data-sortable="true">Github ID</th>
           <th data-sortable="true">Org Membership</th>
           <th></th>
           <th></th>

--- a/app/views/courses/repos.html.erb
+++ b/app/views/courses/repos.html.erb
@@ -3,7 +3,8 @@
 <%= form_tag course_search_repos_path, method: :get do %>
   <div class="input-group">
     <span class="input-group-addon" id="basic-addon1">(.*)</span>
-    <%= text_field_tag :search, (params[:search] or ""), class: 'form-control', placeholder: "Regular Expression Search" %>
+    <%= text_field_tag :search, (params[:search] or ""), class: 'repo-search form-control', placeholder:
+        "Regular Expression Search" %>
   </div>
   <p></p>
   <%= submit_tag "Search", class: 'btn btn-primary' %>

--- a/app/views/layouts/_nav_links_for_auth.html.erb
+++ b/app/views/layouts/_nav_links_for_auth.html.erb
@@ -23,7 +23,7 @@
     </ul>
   </li>
 <% else %>
-  <li><p class="navbar-btn">
+  <li><p class="navbar-btn navbar-signin-btn">
     <%= link_to user_github_omniauth_authorize_path, method: :post, class: 'btn btn-info' do %>
       <%= fa_icon 'github', text: 'Sign in' %>
     <% end %>


### PR DESCRIPTION
This PR implements a variety of minor UI fixes and a couple cool UI features. It does not make any functionality changes. Specifically, it does the following things:

- The nav bar sign in button is no longer half cutoff the page (finally!). This closes #161.
<img width="100" alt="Screen Shot 2020-02-16 at 5 55 44 PM" src="https://user-images.githubusercontent.com/34611522/74618185-91149700-50e5-11ea-88c3-f2468db8e066.png">

- The admin dashboard tables are reordered to be more helpful per the order described in #162:
> Put rate limit at top, jobs, job log, then db tables

Accordingly, this closes #162.

- The table of students on a course page is now even fancier. As a starter, the perm column is now sortable (this closes #163). But more importantly, the table can now be filtered by any one column of the user's choice. For the boolean fields, you can select true or false and it'll filter (this closes #164). For anything else, you can type anything into the input field of that column header, and it'll filter:
<img width="1244" alt="Screen Shot 2020-02-16 at 6 01 47 PM" src="https://user-images.githubusercontent.com/34611522/74618388-68d96800-50e6-11ea-97b4-6cf7375914b5.png">

- Fix some typos and missing strings in job hover text. This closes #160.