### PR TITLE
Significantly improved GitHub API interactions using GraphQL

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -124,7 +124,7 @@ class CoursesController < ApplicationController
 
   # List of course jobs to make available to run
   def course_job_list
-    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob, RepoCollaboratorsJob, PurgeCourseReposJob, UpdateGithubReposJob]
+    [TestJob, StudentsOrgMembershipCheckJob, UpdateGithubReposJob, PurgeCourseReposJob]
   end
   helper_method :course_job_list
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -124,7 +124,7 @@ class CoursesController < ApplicationController
 
   # List of course jobs to make available to run
   def course_job_list
-    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob, RepoCollaboratorsJob, PurgeCourseReposJob]
+    [TestJob, StudentsOrgMembershipCheckJob, RefreshGithubReposJob, RepoCollaboratorsJob, PurgeCourseReposJob, UpdateGithubReposJob]
   end
   helper_method :course_job_list
 

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -3,6 +3,7 @@
 
 class BackgroundJob
   include SuckerPunch::Job
+  include ActionView::Helpers::TextHelper
 
   # Job name: display name of job
   # Job short name: internal job name. Do not change this, it will break the job history

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -18,6 +18,7 @@ class CourseJob < BackgroundJob
     Octokit_Wrapper::Octokit_Wrapper.machine_user
   end
 
+  # TODO: Make this set a course instance variable to avoid code repetition
   def perform(course_id)
     ActiveRecord::Base.connection_pool.with_connection do
       create_in_progress_job_record(course_id)

--- a/app/jobs/students_org_membership_check_job.rb
+++ b/app/jobs/students_org_membership_check_job.rb
@@ -26,8 +26,9 @@ class StudentsOrgMembershipCheckJob < CourseJob
     if !student.is_org_member || student.org_membership_type != org_member.role
       updates_made = true
       student.is_org_member = true
-      student.org_membership_type = org_member.role
+      student.org_membership_type = org_member.role.capitalize
     end
+    student.save
     updates_made ? 1 : 0
   end
   

--- a/app/jobs/update_github_repos_job.rb
+++ b/app/jobs/update_github_repos_job.rb
@@ -1,0 +1,64 @@
+class UpdateGithubReposJob < CourseJob
+  @job_name = "Update All GitHub info"
+  @job_short_name = "update_github_info"
+  @job_description = "Uses smart querying to quickly update GitHub repositories and their collaborators."
+
+  def attempt_job(course_id)
+    course = Course.find(course_id)
+    course_student_users = course.roster_students.map { |rs| rs.user }.select { |u| u != nil }
+    all_org_repos = get_github_repos(course.course_organization).map { |repo| repo.node}
+    binding.pry
+    all_org_repos.each do |repo|
+
+    end
+
+  end
+
+  def create_or_update_repo(repo)
+
+  end
+
+  # We have to manually handle pagination because Octokit has no built-in support for GraphQL
+  def get_github_repos(course_org, cursor = "")
+    response = github_machine_user.post '/graphql', { query: graphql_query(course_org, cursor) }.to_json
+    repo_list = repo_list_from_response(response)
+    if repo_list.count == 0
+      return repo_list
+    end
+    repo_list + get_github_repos(course_org, repo_list.last.cursor)
+  end
+
+  def repo_list_from_response(response)
+    response.data.organization.repositories.edges
+  end
+
+  def graphql_query(course_org, cursor)
+    after_arg = cursor != "" ? ", after: \"#{cursor}\"" : ""
+    <<-GRAPHQL
+      query {
+        organization(login:"#{course_org}") {
+        repositories(first: 100#{after_arg}) {
+          edges {
+            cursor
+            node {
+              name
+              id
+              url
+              nameWithOwner
+              updatedAt
+              isPrivate
+              collaborators(affiliation:DIRECT) {
+                edges {
+                  node {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    GRAPHQL
+  end
+end

--- a/app/jobs/update_github_repos_job.rb
+++ b/app/jobs/update_github_repos_job.rb
@@ -1,5 +1,5 @@
 class UpdateGithubReposJob < CourseJob
-  @job_name = "Update All GitHub info"
+  @job_name = "Update GitHub Repository Info"
   @job_short_name = "update_github_info"
   @job_description = "Uses smart querying to quickly update GitHub repositories and their collaborators."
 
@@ -7,40 +7,66 @@ class UpdateGithubReposJob < CourseJob
     course = Course.find(course_id)
     course_student_users = course.roster_students.map { |rs| rs.user }.select { |u| u != nil }
     all_org_repos = get_github_repos(course.course_organization).map { |repo| repo.node}
-    binding.pry
+
+    num_created = 0; collaborators_found = 0; repos_found_collaborators_for = 0
     all_org_repos.each do |repo|
-
+      num_created += create_or_update_repo(repo, course_id)
+      num_repo_collaborators = create_or_update_collaborators(repo, course_student_users)
+      collaborators_found += num_repo_collaborators
+      repos_found_collaborators_for += num_repo_collaborators > 0 ? 1 : 0
     end
+    num_updated = all_org_repos.count - num_created
 
+    summary = "#{num_created} repos created, #{num_updated} refreshed. #{collaborators_found} collaborators found for
+ #{repos_found_collaborators_for} repos."
+    update_job_record_with_completion_summary(summary)
   end
-
-  def create_or_update_repo(github_repo)
-    num_created = 0
-    repo_record = GithubRepo.new
-    existing_record = GithubRepo.find_by_repo_id(github_repo.id)
+  
+  def create_or_update_repo(github_repo, course_id)
+    existing_record = GithubRepo.find_by_repo_id(github_repo.databaseId)
     unless existing_record.nil?
+      num_created = 0
       repo_record = existing_record
     else
-      num_created += 1
+      num_created = 1
       repo_record = GithubRepo.new
-      repo_record.node_id = github_repo.id
-      repo_record.course = course
+      repo_record.repo_id = github_repo.databaseId
+      repo_record.course_id = course_id
     end
     repo_record.name = github_repo.name
-    repo_record.full_name = github_repo.full_name  # full_name includes organization name e.g. test-org/test-repo
-    repo_record.visibility = github_repo.private ? "private" : "public"
-    repo_record.url = github_repo.html_url
-    repo_record.last_updated_at = github_repo.updated_at
+    repo_record.full_name = github_repo.nameWithOwner  # full_name includes organization name e.g. test-org/test-repo
+    repo_record.visibility = github_repo.isPrivate ? "private" : "public"
+    repo_record.url = github_repo.url
+    repo_record.last_updated_at = github_repo.updatedAt
     repo_record.save
 
     num_created
+  end
+
+  def create_or_update_collaborators(github_repo, course_student_users)
+    usernames = course_student_users.map { |user| user.username }
+    db_repo_record = GithubRepo.find_by_repo_id(github_repo.databaseId)
+    collaborator_list = collaborator_list_from_response_repo(github_repo)
+    filtered_collaborator_list = collaborator_list.select { |collaborator| usernames.include?(collaborator.node.login) }
+    filtered_collaborator_list.each do |collaborator|
+      user = course_student_users.select { |user| user.username == collaborator.node.login }.first
+      existing_record = RepoContributor.find_by(user_id: user.id, github_repo_id: db_repo_record.id)
+      unless existing_record.nil?
+        current_record = existing_record
+      else
+        current_record = RepoContributor.new(user: user, github_repo: db_repo_record)
+      end
+      current_record.permission_level = collaborator.permission.downcase
+      current_record.save
+    end
+    filtered_collaborator_list.count
   end
 
   # We have to manually handle pagination because Octokit has no built-in support for GraphQL
   def get_github_repos(course_org, cursor = "")
     response = github_machine_user.post '/graphql', { query: graphql_query(course_org, cursor) }.to_json
     repo_list = repo_list_from_response(response)
-    if repo_list.count == 0
+    if repo_list.empty?
       return repo_list
     end
     repo_list + get_github_repos(course_org, repo_list.last.cursor)
@@ -48,6 +74,10 @@ class UpdateGithubReposJob < CourseJob
 
   def repo_list_from_response(response)
     response.data.organization.repositories.edges
+  end
+
+  def collaborator_list_from_response_repo(repo_response)
+    repo_response.collaborators.edges
   end
 
   def graphql_query(course_org, cursor)
@@ -60,13 +90,14 @@ class UpdateGithubReposJob < CourseJob
             cursor
             node {
               name
-              id
+              databaseId
               url
               nameWithOwner
               updatedAt
               isPrivate
               collaborators(affiliation:DIRECT) {
                 edges {
+                  permission
                   node {
                     login
                   }

--- a/app/jobs/update_github_repos_job.rb
+++ b/app/jobs/update_github_repos_job.rb
@@ -14,8 +14,26 @@ class UpdateGithubReposJob < CourseJob
 
   end
 
-  def create_or_update_repo(repo)
+  def create_or_update_repo(github_repo)
+    num_created = 0
+    repo_record = GithubRepo.new
+    existing_record = GithubRepo.find_by_repo_id(github_repo.id)
+    unless existing_record.nil?
+      repo_record = existing_record
+    else
+      num_created += 1
+      repo_record = GithubRepo.new
+      repo_record.node_id = github_repo.id
+      repo_record.course = course
+    end
+    repo_record.name = github_repo.name
+    repo_record.full_name = github_repo.full_name  # full_name includes organization name e.g. test-org/test-repo
+    repo_record.visibility = github_repo.private ? "private" : "public"
+    repo_record.url = github_repo.html_url
+    repo_record.last_updated_at = github_repo.updated_at
+    repo_record.save
 
+    num_created
   end
 
   # We have to manually handle pagination because Octokit has no built-in support for GraphQL

--- a/app/jobs/update_github_repos_job.rb
+++ b/app/jobs/update_github_repos_job.rb
@@ -5,7 +5,7 @@ class UpdateGithubReposJob < CourseJob
 
   def attempt_job(course_id)
     course = Course.find(course_id)
-    course_student_users = course.roster_students.map { |rs| rs.user }.select { |u| u != nil }
+    course_student_users = course.roster_students.map { |rs| rs.user }.compact
     all_org_repos = get_github_repos(course.course_organization).map { |repo| repo.node}
 
     num_created = 0; collaborators_found = 0; repos_found_collaborators_for = 0

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -91,8 +91,8 @@
             <td><%= student.last_name %></td>
             <td><%= student.email %></td>
             <td><%= student.enrolled ? "True" : "False" %></td>
-            <td><%= !student.user.nil? and student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
-            <% if !student.username.nil? and !student.username.empty? %>
+            <td><%= !student.user.nil? && student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
+            <% if !student.username.nil? && !student.username.empty? %>
               <td><a href="https://github.com/<%= student.username %>"><%= student.username %></td>
               <td><%= student.is_org_member ? "True" : "False" %></td>
             <% else %>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -94,7 +94,7 @@
             <td><%= !student.user.nil? && student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
             <% if !student.username.nil? && !student.username.empty? %>
               <td><a href="https://github.com/<%= student.username %>"><%= student.username %></td>
-              <td><%= student.is_org_member ? "True" : "False" %></td>
+              <td><%= student.org_membership_type %></td>
             <% else %>
               <td></td>
               <td></td>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -92,13 +92,12 @@
             <td><%= student.email %></td>
             <td><%= student.enrolled ? "True" : "False" %></td>
             <td><%= !student.user.nil? && student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
-            <% if !student.username.nil? && !student.username.empty? %>
+            <% if !student.user.nil? %>
               <td><a href="https://github.com/<%= student.username %>"><%= student.username %></td>
-              <td><%= student.org_membership_type %></td>
             <% else %>
               <td></td>
-              <td></td>
             <% end %>
+              <td><%= student.org_membership_type.present? ? student.org_membership_type : "Non-member" %></td>
             <td><%= link_to 'Show', course_roster_student_path(@course, student) %></td>
             <td><%= link_to 'Edit', edit_course_roster_student_path(@course, student) %></td>
             <% if can? :destroy, student %>

--- a/db/migrate/20200217182646_add_node_id_to_github_repos.rb
+++ b/db/migrate/20200217182646_add_node_id_to_github_repos.rb
@@ -1,0 +1,5 @@
+class AddNodeIdToGithubRepos < ActiveRecord::Migration[5.1]
+  def change
+    add_column :github_repos, :node_id, :string
+  end
+end

--- a/db/migrate/20200217182646_add_node_id_to_github_repos.rb
+++ b/db/migrate/20200217182646_add_node_id_to_github_repos.rb
@@ -1,5 +1,0 @@
-class AddNodeIdToGithubRepos < ActiveRecord::Migration[5.1]
-  def change
-    add_column :github_repos, :node_id, :string
-  end
-end

--- a/db/migrate/20200218024140_add_org_membership_type_to_roster_students.rb
+++ b/db/migrate/20200218024140_add_org_membership_type_to_roster_students.rb
@@ -1,0 +1,5 @@
+class AddOrgMembershipTypeToRosterStudents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :roster_students, :org_membership_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200201195311) do
+ActiveRecord::Schema.define(version: 20200217182646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20200201195311) do
     t.integer "repo_id"
     t.string "full_name"
     t.string "visibility"
+    t.string "node_id"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200217182646) do
+ActiveRecord::Schema.define(version: 20200201195311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,7 +43,6 @@ ActiveRecord::Schema.define(version: 20200217182646) do
     t.integer "repo_id"
     t.string "full_name"
     t.string "visibility"
-    t.string "node_id"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200201195311) do
+ActiveRecord::Schema.define(version: 20200218024140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20200201195311) do
     t.bigint "user_id"
     t.boolean "enrolled", default: true
     t.boolean "is_org_member"
+    t.string "org_membership_type"
     t.index ["course_id"], name: "index_roster_students_on_course_id"
     t.index ["email", "course_id"], name: "index_roster_students_on_email_and_course_id", unique: true
     t.index ["perm", "course_id"], name: "index_roster_students_on_perm_and_course_id", unique: true


### PR DESCRIPTION
Here's a helpful one. This PR implements GitHub API job functionality using the GraphQL interface to dramatically speed up processing and avoid counting too hard against the rate limit. It does the following:

- A new job is implemented: UpdateGithubReposJob. This job uses GraphQL to make one query to get all of an organization's repositories **and** their direct collaborators. This means we can effectively combine the RepoCollaboratorJob and RefreshGithubReposJob into one and, much more importantly, we don't need to make one query for every repository to get the collaborators. Whereas the old RepoCollaborator job was O(n) for n repositories, this is O(1).
- Refresh student org membership is also upgraded to GraphQL to implement the functionality requested in #136. The org membership column of the student table now shows "admin", "member", or "non-member" for students with associated users. A db migration to add a column for that is added to facilitate this change. This closes #136. 
- RepoCollaboratorJob and RefreshGithubReposJob are not removed for the time being but are now hidden from view, as their functionality is wholly replaced by UpdateGithubReposJob.

This closes #167.