### PR TITLE
Create GitHub teams from CSV

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -42,15 +42,27 @@ class AdminController < ApplicationController
 
     def rate_limits
       rate_limits = Hash.new
-      rate_limits["GitHub API"] = github_rate_limit
+      rate_limits["GitHub v3 API (REST)"] = github_v3_rate_limit
+      rate_limits["GitHub v4 API (GraphQL)"] = github_v4_rate_limit
       rate_limits
     end
     helper_method :rate_limits
 
   private
-    def github_rate_limit
+    def github_v3_rate_limit
+      limit_response = machine_user.rate_limit
+      if limit_response.respond_to? :limit
+        reset_time = Time.at(limit_response.resets_at)
+        return {"remaining": limit_response.remaining, "limit": limit_response.limit, "reset": reset_time,
+                "until_reset": distance_of_time_in_words_to_now(reset_time), "info": "GitHub Machine User: " +
+                ENV['MACHINE_USER_NAME']}
+      end
+      {"error": "Rate limit API request failed. Try refreshing the page."}
+    end
+
+    def github_v4_rate_limit
       limit_response = Octokit_Wrapper::Octokit_Wrapper.machine_user.post '/graphql', { query: rate_limit_graphql_query }.to_json
-      if limit_response.data.present?
+      if limit_response.respond_to? :data
         rateLimitInfo = limit_response.data.rateLimit
         reset_time = Time.parse(rateLimitInfo.resetAt)
         return {"remaining": rateLimitInfo.remaining, "limit": rateLimitInfo.limit, "reset": reset_time,

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -50,7 +50,7 @@ class AdminController < ApplicationController
 
   private
     def github_v3_rate_limit
-      limit_response = machine_user.rate_limit
+      limit_response = github_machine_user.rate_limit
       if limit_response.respond_to? :limit
         reset_time = Time.at(limit_response.resets_at)
         return {"remaining": limit_response.remaining, "limit": limit_response.limit, "reset": reset_time,
@@ -61,7 +61,7 @@ class AdminController < ApplicationController
     end
 
     def github_v4_rate_limit
-      limit_response = Octokit_Wrapper::Octokit_Wrapper.machine_user.post '/graphql', { query: rate_limit_graphql_query }.to_json
+      limit_response = github_machine_user.post '/graphql', { query: rate_limit_graphql_query }.to_json
       if limit_response.respond_to? :data
         rateLimitInfo = limit_response.data.rateLimit
         reset_time = Time.parse(rateLimitInfo.resetAt)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,8 @@ class ApplicationController < ActionController::Base
       format.js   { head :forbidden, content_type: 'text/html' }
     end
   end
+
+  def github_machine_user
+    Octokit_Wrapper::Octokit_Wrapper.machine_user
+  end
 end

--- a/app/controllers/courses/teams_controller.rb
+++ b/app/controllers/courses/teams_controller.rb
@@ -30,6 +30,23 @@ module Courses
 
     end
 
+    def generate_teams
+      team_csv = params[:file]
+      team_hash = Hash.new
+      ignore_first_row = params[:ignore_first_row]
+      CSV.foreach(team_csv.path) do |row|
+        if ignore_first_row != 0
+          ignore_first_row = 0
+          next
+        end
+        team_name = row[1].strip
+        team_hash[team_name] ||= []
+        team_hash[team_name] << row[0].strip
+      end
+      CreateGithubTeamsJob.perform_async(@course.id, { :teams => team_hash })
+      redirect_to course_teams_path(@course), notice: "Team creation successfully queued."
+    end
+
     private
       def load_parent
         @parent = Course.find(params[:course_id])

--- a/app/controllers/courses/teams_controller.rb
+++ b/app/controllers/courses/teams_controller.rb
@@ -21,7 +21,8 @@ module Courses
       unless repo_name_pattern.include?("{team}")
         redirect_to course_teams_path(@course), alert: "Your naming pattern must include {team} in it."
       end
-      CreateTeamReposJob.perform_async(@parent.id, team_name_pattern, repo_name_pattern, permission_level, visibility)
+      options = {:team_pattern => team_name_pattern, :repo_pattern => repo_name_pattern, :permission_level => permission_level, :visibility => visibility}
+      CreateTeamReposJob.perform_async(@parent.id, options)
       redirect_to course_teams_path(@course), notice: "Repository creation successfully queued."
     end
 

--- a/app/controllers/courses/teams_controller.rb
+++ b/app/controllers/courses/teams_controller.rb
@@ -35,7 +35,7 @@ module Courses
       team_hash = Hash.new
       ignore_first_row = params[:ignore_first_row]
       CSV.foreach(team_csv.path) do |row|
-        if ignore_first_row != 0
+        if ignore_first_row.present? && ignore_first_row != 0
           ignore_first_row = 0
           next
         end

--- a/app/controllers/courses/teams_controller.rb
+++ b/app/controllers/courses/teams_controller.rb
@@ -10,7 +10,7 @@ module Courses
     end
 
     def create_repos
-      authorize! :create_repos, @course
+
     end
 
     def generate_repos
@@ -21,9 +21,13 @@ module Courses
       unless repo_name_pattern.include?("{team}")
         redirect_to course_teams_path(@course), alert: "Your naming pattern must include {team} in it."
       end
-      options = {:team_pattern => team_name_pattern, :repo_pattern => repo_name_pattern, :permission_level => permission_level, :visibility => visibility}
+      options = { :team_pattern => team_name_pattern, :repo_pattern => repo_name_pattern, :permission_level => permission_level, :visibility => visibility }
       CreateTeamReposJob.perform_async(@parent.id, options)
       redirect_to course_teams_path(@course), notice: "Repository creation successfully queued."
+    end
+
+    def create_teams
+
     end
 
     private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -164,10 +164,6 @@ class CoursesController < ApplicationController
       current_user.add_role :instructor, Course.find(id)
     end
 
-    def machine_user
-      client = Octokit_Wrapper::Octokit_Wrapper.machine_user
-    end
-
     def session_user
       client = Octokit_Wrapper::Octokit_Wrapper.session_user(session[:token])
     end

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -55,11 +55,11 @@ class BackgroundJob
     job_record.save
   end
 
-  def perform
+  def perform(options = {})
     ActiveRecord::Base.connection_pool.with_connection do
       begin
         create_in_progress_job_record
-        summary = attempt_job || empty_job_summary
+        summary = attempt_job(options) || empty_job_summary
         update_job_record_with_completion_summary(summary)
       rescue Exception => e
         rescue_job(e)
@@ -67,7 +67,7 @@ class BackgroundJob
     end
   end
 
-  def attempt_job
+  def attempt_job(options)
     # What a job actually does
 
   end

--- a/app/jobs/course/associate_slack_users_job.rb
+++ b/app/jobs/course/associate_slack_users_job.rb
@@ -3,7 +3,7 @@ class AssociateSlackUsersJob < CourseJob
   @job_short_name = "associate_slack_users"
   @job_description = "Fetches a list of users in the linked Slack workspace and associates them by email with students in the course."
 
-  def attempt_job
+  def attempt_job(options)
     slack_members = []
     slack_machine_user.users_list do |response|
       slack_members.concat(response.members)

--- a/app/jobs/course/create_github_teams_job.rb
+++ b/app/jobs/course/create_github_teams_job.rb
@@ -1,4 +1,8 @@
 class CreateGithubTeamsJob < CourseJob
+  @job_name = "Create GitHub Teams"
+  @job_short_name = "create_github_teams"
+  @job_description = "Generates GitHub teams from an uploaded CSV file of users and their associated teams."
+
   def attempt_job(options)
     teams_to_create = options[:teams]
     current_user = github_machine_user.user.login
@@ -32,7 +36,10 @@ class CreateGithubTeamsJob < CourseJob
         puts e
       end
     end
-    "#{pluralize teams_created, "team"} created and #{pluralize users_added, "user"} to teams. Failed to create #{pluralize teams_not_created, "team"} and
-failed to add #{pluralize users_not_added, "user"}"
+    # Now, we just refresh all the teams to make sure we have the most up-to-date data. We use #perform and not #perform_async
+    # because we don't want this job to complete until the local data is up to date.
+    RefreshGithubTeamsJob.new.perform(@course.id)
+    "#{pluralize teams_created, "team"} created and added #{pluralize users_added, "user"} to teams. Failed to create #{pluralize teams_not_created, "team"} and
+failed to add #{pluralize users_not_added, "user"} to teams."
   end
 end

--- a/app/jobs/course/create_github_teams_job.rb
+++ b/app/jobs/course/create_github_teams_job.rb
@@ -10,7 +10,7 @@ class CreateGithubTeamsJob < CourseJob
     # it blows up the whole operation. So, we just do everything one by one for safety.
     # These operations with unverified data are very exception prone, and we don't want one already-existing team or
     # failed user add to crash the whole thing, so all the requests are wrapped in exception handling blocks.
-    teams_created = 0; users_added = 0; teams_not_created = 0; users_not_added = 0
+    teams_created = 0; users_added = 0; teams_not_created = 0
     teams_to_create.each do |team_name, members|
       begin
         response = github_machine_user.create_team(@course.course_organization, { :name => team_name, :privacy => "closed" })
@@ -29,7 +29,6 @@ class CreateGithubTeamsJob < CourseJob
         begin
           github_machine_user.add_team_member(team_id, user)
         rescue Octokit::Error => e
-          users_not_added += 1
           puts e
         end
       end
@@ -45,7 +44,6 @@ class CreateGithubTeamsJob < CourseJob
     # Now, we just refresh all the teams to make sure we have the most up-to-date data. We use #perform and not #perform_async
     # because we don't want this job to complete until the local data is up to date.
     RefreshGithubTeamsJob.new.perform(@course.id)
-    "#{pluralize teams_created, "team"} created and added #{pluralize users_added, "user"} to teams. Failed to create #{pluralize teams_not_created, "team"} and
-failed to add #{pluralize users_not_added, "user"} to teams."
+    "#{pluralize teams_created, "team"} created and added #{pluralize users_added, "user"} to teams. Failed to create #{pluralize teams_not_created, "team"}."
   end
 end

--- a/app/jobs/course/create_github_teams_job.rb
+++ b/app/jobs/course/create_github_teams_job.rb
@@ -1,5 +1,38 @@
 class CreateGithubTeamsJob < CourseJob
   def attempt_job(options)
-
+    teams_to_create = options[:teams]
+    current_user = github_machine_user.user.login
+    # There is a way to create teams with a list of maintainers, but if there is a problem with any one of those maintainers,
+    # it blows up the whole operation. So, we just do everything one by one for safety.
+    # These operations with unverified data are very exception prone, and we don't want one already-existing team or
+    # failed user add to crash the whole thing, so all the requests are wrapped in exception handling blocks.
+    teams_created = 0; users_added = 0; teams_not_created = 0; users_not_added = 0
+    teams_to_create.each do |team_name, members|
+      begin
+        response = github_machine_user.create_team(@course.course_organization, { :name => team_name, :privacy => "closed" })
+        teams_created += 1
+        members.each do |user|
+          begin
+            github_machine_user.add_team_member(response.id, user)
+          rescue Octokit::Error => e
+            users_not_added += 1
+            puts e
+          end
+        end
+        unless members.include? current_user
+          begin
+            github_machine_user.remove_team_member(response.id, current_user)
+            users_added += 1
+          rescue Octokit::Error => e
+            puts e
+          end
+        end
+      rescue Octokit::Error => e
+        teams_not_created += 1
+        puts e
+      end
+    end
+    "#{pluralize teams_created, "team"} created and #{pluralize users_added, "user"} to teams. Failed to create #{pluralize teams_not_created, "team"} and
+failed to add #{pluralize users_not_added, "user"}"
   end
 end

--- a/app/jobs/course/create_github_teams_job.rb
+++ b/app/jobs/course/create_github_teams_job.rb
@@ -27,7 +27,7 @@ class CreateGithubTeamsJob < CourseJob
       end
       members.each do |user|
         begin
-          github_machine_user.add_team_member(team_id, user)
+          github_machine_user.put("teams/#{team_id}/memberships/#{user}", { :role => "maintainer" })
         rescue Octokit::Error => e
           puts e
         end

--- a/app/jobs/course/create_github_teams_job.rb
+++ b/app/jobs/course/create_github_teams_job.rb
@@ -1,0 +1,5 @@
+class CreateGithubTeamsJob < CourseJob
+  def attempt_job(options)
+
+  end
+end

--- a/app/jobs/course/create_github_teams_job.rb
+++ b/app/jobs/course/create_github_teams_job.rb
@@ -15,25 +15,31 @@ class CreateGithubTeamsJob < CourseJob
       begin
         response = github_machine_user.create_team(@course.course_organization, { :name => team_name, :privacy => "closed" })
         teams_created += 1
-        members.each do |user|
-          begin
-            github_machine_user.add_team_member(response.id, user)
-          rescue Octokit::Error => e
-            users_not_added += 1
-            puts e
-          end
-        end
-        unless members.include? current_user
-          begin
-            github_machine_user.remove_team_member(response.id, current_user)
-            users_added += 1
-          rescue Octokit::Error => e
-            puts e
-          end
-        end
       rescue Octokit::Error => e
         teams_not_created += 1
         puts e
+      end
+      if response.present?
+        team_id = response.id
+      else
+        # There is an exception response if the team already exists. So, we calculate what the team slug is in that case and use it instead.
+        team_id = team_name.gsub(/[^0-9a-z]/i, '-')
+      end
+      members.each do |user|
+        begin
+          github_machine_user.add_team_member(team_id, user)
+        rescue Octokit::Error => e
+          users_not_added += 1
+          puts e
+        end
+      end
+      unless members.include? current_user
+        begin
+          github_machine_user.remove_team_member(team_id, current_user)
+          users_added += 1
+        rescue Octokit::Error => e
+          puts e
+        end
       end
     end
     # Now, we just refresh all the teams to make sure we have the most up-to-date data. We use #perform and not #perform_async

--- a/app/jobs/course/purge_course_repos_job.rb
+++ b/app/jobs/course/purge_course_repos_job.rb
@@ -1,11 +1,12 @@
 class PurgeCourseReposJob < CourseJob
 
-  @job_name = "Purge Course GitHub Repo Records"
+  @job_name = "Purge Course GitHub Records"
   @job_short_name = "purge_course_repos"
-  @job_description = "Removes all cached records of this course organization's GitHub repos from the database."
+  @job_description = "Removes all cached records of this course organization's GitHub repos and teams from the database. Users will not be removed."
 
   def attempt_job(options)
     destroyed_repos = GithubRepo.where(:course_id => @course.id).destroy_all
-    "Purged #{pluralize destroyed_repos.size, "record"} from the database."
+    destroyed_teams = OrgTeam.where(:course_id => @course.id).destroy_all
+    "Purged #{pluralize destroyed_repos.size, "repo record"} and #{pluralize destroyed_teams.size, "team record"} from the database."
   end
 end

--- a/app/jobs/course/purge_course_repos_job.rb
+++ b/app/jobs/course/purge_course_repos_job.rb
@@ -4,7 +4,7 @@ class PurgeCourseReposJob < CourseJob
   @job_short_name = "purge_course_repos"
   @job_description = "Removes all cached records of this course organization's GitHub repos from the database."
 
-  def attempt_job
+  def attempt_job(options)
     destroyed_repos = GithubRepo.where(:course_id => @course.id).destroy_all
     "Purged #{pluralize destroyed_repos.size, "record"} from the database."
   end

--- a/app/jobs/course/refresh_github_teams_job.rb
+++ b/app/jobs/course/refresh_github_teams_job.rb
@@ -3,7 +3,7 @@ class RefreshGithubTeamsJob < CourseJob
   @job_short_name = "refresh_github_teams"
   @job_description = "Refreshes GitHub teams associated with this course's organization and updates their membership."
 
-  def attempt_job
+  def attempt_job(options)
     course_student_users = @course.roster_students.map.select { |student| student.user.present? }
     results = refresh_teams(course_student_users)
     "#{pluralize results[:num_created], "team"} created, #{results[:num_updated]} updated."

--- a/app/jobs/course/students_org_membership_check_job.rb
+++ b/app/jobs/course/students_org_membership_check_job.rb
@@ -5,7 +5,7 @@ class StudentsOrgMembershipCheckJob < CourseJob
   @job_description = "Fetches org members from GitHub and updates all students' cached org membership status in
 the database."
 
-  def attempt_job
+  def attempt_job(options)
     org_members = get_org_members(@course.course_organization)
     num_changed = 0
     org_members.each do |member|

--- a/app/jobs/course/test_job.rb
+++ b/app/jobs/course/test_job.rb
@@ -4,7 +4,7 @@ class TestJob < CourseJob
   @job_short_name = "test_job"
   @job_description = "Adds a completed job record for this course for testing purposes."
 
-  def attempt_job
+  def attempt_job(options)
     "Test completed."
   end
 end

--- a/app/jobs/course/update_github_repos_job.rb
+++ b/app/jobs/course/update_github_repos_job.rb
@@ -66,7 +66,6 @@ class UpdateGithubReposJob < CourseJob
     filtered_collaborator_list.count
   end
 
-  # TODO: Figure out how to refactor this GraphQL handling code so it doesn't have to be constantly repeated
   # We have to manually handle pagination because Octokit has no built-in support for GraphQL
   def get_github_repos(course_org, cursor = "")
     response = github_machine_user.post '/graphql', { query: repository_graphql_query(course_org, cursor) }.to_json

--- a/app/jobs/course/update_github_repos_job.rb
+++ b/app/jobs/course/update_github_repos_job.rb
@@ -3,7 +3,7 @@ class UpdateGithubReposJob < CourseJob
   @job_short_name = "update_github_info"
   @job_description = "Uses smart querying to quickly update GitHub repositories, and their respective individual and team collaborators."
 
-  def attempt_job
+  def attempt_job(options)
     course_student_users = @course.users
 
     all_org_repos = get_github_repos(@course.course_organization).map { |repo| repo.node}

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -22,7 +22,6 @@ class CourseJob < BackgroundJob
     Slack::Web::Client.new({ :token => @course.slack_workspace.bot_access_token })
   end
 
-  # TODO: Refactor so that all #attempt_job's return a string summary and perform updates the db record.
   def perform(course_id, options = {})
     ActiveRecord::Base.connection_pool.with_connection do
       @course = Course.find(course_id)
@@ -30,7 +29,7 @@ class CourseJob < BackgroundJob
       begin
         summary = attempt_job(options) || empty_job_summary
         update_job_record_with_completion_summary(summary)
-      rescue Exception => e
+      rescue StandardError => e
         rescue_job(e)
       end
     end

--- a/app/jobs/course_job.rb
+++ b/app/jobs/course_job.rb
@@ -23,20 +23,16 @@ class CourseJob < BackgroundJob
   end
 
   # TODO: Refactor so that all #attempt_job's return a string summary and perform updates the db record.
-  def perform(course_id)
+  def perform(course_id, options = {})
     ActiveRecord::Base.connection_pool.with_connection do
       @course = Course.find(course_id)
       create_in_progress_job_record
       begin
-        summary = attempt_job || empty_job_summary
+        summary = attempt_job(options) || empty_job_summary
         update_job_record_with_completion_summary(summary)
       rescue Exception => e
         rescue_job(e)
       end
     end
-  end
-
-  def attempt_job
-
   end
 end

--- a/app/views/courses/teams/create_teams.html.erb
+++ b/app/views/courses/teams/create_teams.html.erb
@@ -1,1 +1,26 @@
 <h1> <%= link_to @course.name, course_path(@course) %> </h1>
+
+<p>On this page, you can upload a CSV to automatically generate GitHub teams with members in them. The CSV should include
+two columns: GitHub ID first, and the team to assign that GitHub user two in the second column. For example:</p>
+
+<samp>
+  bob13,Instructors<br>
+  steve18,TAs<br>
+  charlie24,Students<br>
+  mary40,Instructors<br>
+  steve18,Students<br>
+</samp>
+
+<p>will create 3 teams: Students, TAs, and Instructors.</p>
+<p><b>NOTE:</b> GitHub usernames are case sensitive. This is a limitation of the GitHub API.</p>
+<div class="panel panel-default">
+  <div class="panel-body">
+<%= form_tag generate_teams_course_teams_path, method: :post, multipart: true, class: "form-inline" do %>
+  <%= file_field_tag :file %>
+  <%= label_tag "Ignore first row" %>
+  <%= check_box_tag :ignore_first_row%>
+  <p></p>
+  <%= submit_tag( "Upload" ) %>
+<% end %>
+  </div>
+</div>

--- a/app/views/courses/teams/create_teams.html.erb
+++ b/app/views/courses/teams/create_teams.html.erb
@@ -1,0 +1,1 @@
+<h1> <%= link_to @course.name, course_path(@course) %> </h1>

--- a/app/views/courses/teams/show.html.erb
+++ b/app/views/courses/teams/show.html.erb
@@ -11,7 +11,7 @@
 </h1>
 <p></p>
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-  <% collapsed = "in" # slightly messy way to make only the first panel expanded on page load %>
+  <% collapsed = "in" # slightly messy way to make only the first panel expanded on page load while allowing more than one to be expanded at a time %>
   <% @teams.each do |team| %>
     <div class="panel panel-default">
       <div class="panel-heading" role="tab" id="heading<%= team.id %>">

--- a/app/views/courses/teams/show.html.erb
+++ b/app/views/courses/teams/show.html.erb
@@ -1,5 +1,14 @@
 <h1> <%= link_to @course.name, course_path(@course) %>
-  <%= link_to 'Create Team Repositories', create_repos_course_teams_path, class: "btn btn-primary pull-right", role: "button" %></h1>
+  <div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
+    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Manage Teams <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li> <%= link_to 'Create Teams from CSV', create_repos_course_teams_path%></li>
+      <li> <%= link_to 'Create Team Repositories', create_repos_course_teams_path%> </li>
+    </ul>
+  </div>
+</h1>
 <p></p>
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   <% collapsed = "in" # slightly messy way to make only the first panel expanded on page load %>

--- a/app/views/courses/teams/show.html.erb
+++ b/app/views/courses/teams/show.html.erb
@@ -4,7 +4,7 @@
       Manage Teams <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
-      <li> <%= link_to 'Create Teams from CSV', create_repos_course_teams_path%></li>
+      <li> <%= link_to 'Create Teams from CSV', create_teams_course_teams_path%></li>
       <li> <%= link_to 'Create Team Repositories', create_repos_course_teams_path%> </li>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
           get :create_repos
           post :generate_repos
           get :create_teams
+          post :generate_teams
         end
       end
       # While this is somewhat frowned upon in Rails convention, I refuse to name the controller "SlacksController"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
         collection do
           get :create_repos
           post :generate_repos
+          get :create_teams
         end
       end
       # While this is somewhat frowned upon in Rails convention, I refuse to name the controller "SlacksController"


### PR DESCRIPTION
Full disclosure: this is messy and probably not that useful.

This PR implements the functionality described in #194 (and, as such, closes #194). It does the following things:

- Refactored job code to use an options hash in perform method to allow for any number of parameters to be passed to a job. No functionality changes here, but that's what all those ``options`` variables are.
- Minor refactor of github_machine_user into ``ApplicationController`` so the machine user code isn't repeated in a bunch of controllers.
- Adds the GitHub v3 API rate limit to admin dashboard. The v4 API does not support creating teams and editing their membership, so the new stuff relies on v3.
- A new view is added at endpoint ``/courses/:course_id/teams/create_teams`` and can be accessed via the "Manage Teams" menu on the teams show page of a course:
![Screen Shot 2020-03-31 at 10 04 43 PM](https://user-images.githubusercontent.com/34611522/78101211-a430ad00-739b-11ea-9daa-4c421e44f07a.png)
<img width="726" alt="Screen Shot 2020-03-31 at 10 07 13 PM" src="https://user-images.githubusercontent.com/34611522/78101358-24571280-739c-11ea-8ba2-07c83d7bc60e.png">
Your reaction may be that this view is kind of ugly. I agree.

- Upon uploading and submitting a CSV, a new job is triggered: ``CreateGithubTeamsJob``. It is passed a hash created from the CSV in which each key is a team name and each value is an array of its members. The central purpose of this job is to somehow not crash in the face of all the bullshit Github throws at it as it tries to create teams and add members to them. Here's why it kinda sucks:
    -  The big issue lies in the fact that when you try to create a team that already exists, instead of some useful response indicating that the team already exists, Octokit throws an exception. The same applies for adding a user to a team they're already in. So this job turns into a bit of begin/rescue spaghetti to work around that and do its best to create teams and populate them even if they already existed.
    - A secondary issue is that GitHub's endpoint for adding users to a team is case sensitive with regards to the username. I left a warning on the upload page, but it's annoying and will inevitably cause issues anyway.
    - Finally, because this functionality is not included in the GraphQL API, we're back to the stone age of one-by-one REST API calls which sucks for performance and conciseness reasons.

In conclusion, the GitHub API's team functionality is pretty anemic and this functionality isn't able to shroud much of that away. This feature works for the time being, but probably a smarter team creation functionality that involves students/emails rather than directly referencing GitHub IDs is much easier to use, though it would require a lot more implementation work.