### PR TITLE
Added section to roster student, improved /whois slack command

### DIFF
--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -23,7 +23,7 @@ $(document).ready(function () {
 
             var fields = [{value: 'select', name: '-- select --'}, {value: 'full_name', name: 'Full Name'},
                 {value: 'first_name', name: 'First Name'}, {value: 'last_name', name: 'Last Name'},
-                {value: 'perm', name: 'Student ID'}, {value: 'email', name: 'Email'}];
+                {value: 'perm', name: 'Student ID'}, {value: 'email', name: 'Email'}, {value: 'section', name: 'Section'}];
 
             for (var i = 0; i < fields.length; i++) {
                 dropdownHtml += "<option value='" + fields[i].value + "' >" + fields[i].name + "</option>";

--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -23,7 +23,7 @@ $(document).ready(function () {
 
             var fields = [{value: 'select', name: '-- select --'}, {value: 'full_name', name: 'Full Name'},
                 {value: 'first_name', name: 'First Name'}, {value: 'last_name', name: 'Last Name'},
-                {value: 'perm', name: 'Student ID'}, {value: 'email', name: 'Email'}, {value: 'section', name: 'Section'}];
+                {value: 'student_id', name: 'Student ID'}, {value: 'email', name: 'Email'}, {value: 'section', name: 'Section'}];
 
             for (var i = 0; i < fields.length; i++) {
                 dropdownHtml += "<option value='" + fields[i].value + "' >" + fields[i].name + "</option>";
@@ -169,13 +169,13 @@ $(document).ready(function () {
      console.log(headings);
  
      var full_split_name_error = headings.includes("full_name") && (headings.includes("first_name") || headings.includes("first_name"));
-     var missing_perm = !headings.includes("perm");
+     var missing_student_id = !headings.includes("student_id");
      var missing_email = !headings.includes("email");
      var any_missing = headings.includes("invalid");
      var first_name_wo_last_name = headings.includes("first_name") && !headings.includes("last_name");
      var last_name_wo_first_name = headings.includes("last_name") && !headings.includes("first_name");
  
-     if (full_split_name_error || missing_perm || missing_email || first_name_wo_last_name || last_name_wo_first_name || any_missing) {
+     if (full_split_name_error || missing_student_id || missing_email || first_name_wo_last_name || last_name_wo_first_name || any_missing) {
          if ($("#csv-upload-error").hasClass('hidden')) {
              $("#csv-upload-error").removeClass( "hidden" );
          } else {

--- a/app/controllers/courses/roster_students_controller.rb
+++ b/app/controllers/courses/roster_students_controller.rb
@@ -67,7 +67,7 @@ module Courses
     def update
       respond_to do |format|
         if @roster_student.update(roster_student_params)
-          format.html { redirect_to course_path(@parent), notice: 'Roster student was successfully updated.' }
+          format.html { redirect_to course_roster_student_path(@parent, @roster_student), notice: 'Roster student was successfully updated.' }
           format.json { render :show, status: :ok, location: @roster_student }
         else
           format.html { render :edit }
@@ -103,7 +103,7 @@ module Courses
 
       # Never trust parameters from the scary internet, only allow the white list through.
       def roster_student_params
-        params.require(:roster_student).permit(:perm, :first_name, :last_name, :email, :enrolled)
+        params.require(:roster_student).permit(:perm, :first_name, :last_name, :email, :enrolled, :section)
       end
 
       def load_parent

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -29,7 +29,12 @@ module Slack
             github_str = github_id ? "<https://github.com/#{github_id}|#{github_id}>" : "N/A"
             # Markdown linking to student show page
             student_name_str = "<#{course_roster_student_url(workspace.course.id, matched_student.id)}|#{matched_student.full_name}>"
-            command_output += "*GitHub ID:* #{github_str}, *Student:* #{student_name_str}"
+            teams_str = ""
+            matched_student.org_teams.each do |team|
+              teams_str += "<#{team.url}|#{team.name}>, "
+            end
+            teams_str.empty? ? teams_str.delete_suffix!(", ") : teams_str = "N/A"
+            command_output += "*GitHub ID:* #{github_str}, *Student:* #{student_name_str}, *Teams:* #{teams_str}"
             unless index == user_id_matches.size - 1
               command_output += "\n"
             end

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -21,7 +21,7 @@ module Slack
       else
         command_output = ""
         @students = workspace.course.roster_students.select { |student| student.slack_user.present? }
-        user_id_matches.each do |match, index|
+        user_id_matches.each do |match|
           matched_student = @students.find { |student| student.slack_user.uid == match }
           if matched_student.present?
             github_id = matched_student.username
@@ -35,14 +35,9 @@ module Slack
             end
             teams_str.empty? ? teams_str.delete_suffix!(", ") : teams_str = "N/A"
             command_output += "*GitHub ID:* #{github_str}, *Student:* #{student_name_str}, *Teams:* #{teams_str}"
-            unless index == user_id_matches.size - 1
-              command_output += "\n"
-            end
           end
         end
-        if command_output == ""
-          command_output = "No students found for the provided user(s)."
-        end
+        command_output.empty? ? command_output = "No students found for the provided user(s)." : command_output.delete_suffix!("\n")
         render json: { :text => command_output }
       end
     end

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -34,7 +34,8 @@ module Slack
               teams_str += "<#{team.url}|#{team.name}>, "
             end
             teams_str.empty? ? teams_str.delete_suffix!(", ") : teams_str = "N/A"
-            command_output += "*GitHub ID:* #{github_str}, *Student:* #{student_name_str}, *Teams:* #{teams_str}"
+            section_str = matched_student.section
+            command_output += "*GitHub ID:* #{github_str}, *Student:* #{student_name_str}, *Section:* #{section_str} *Teams:* #{teams_str}"
           end
         end
         command_output.empty? ? command_output = "No students found for the provided user(s)." : command_output.delete_suffix!("\n")

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -64,6 +64,7 @@ class Course < ApplicationRecord
     first_name_index = header_map.index("first_name")
     last_name_index = header_map.index("last_name")
     full_name_index = header_map.index("full_name")
+    section_index = header_map.index("section")
 
     unenroll_all_students
 
@@ -76,6 +77,7 @@ class Course < ApplicationRecord
 
       row["perm"] = spreadsheet_row[id_index]
       row["email"] = spreadsheet_row[email_index]
+      row["section"] = spreadsheet_row[section_index]
 
       if first_name_index
         row["first_name"] = spreadsheet_row[first_name_index]
@@ -97,6 +99,7 @@ class Course < ApplicationRecord
       student.first_name = row["first_name"]
       student.last_name = row["last_name"]
       student.email = row["email"]
+      student.section = row["section"]
       student.save
     end
   end
@@ -104,7 +107,7 @@ class Course < ApplicationRecord
   # export roster students to a CSV file
   def export_students_to_csv
     CSV.generate(headers: true) do |csv|
-      csv << %w[studentId email first_name last_name github_username enrolled]
+      csv << %w[studentId email first_name last_name enrolled section github_username org_member_status]
 
       roster_students.each do |user|
         csv << [
@@ -112,8 +115,10 @@ class Course < ApplicationRecord
           user.email,
           user.first_name,
           user.last_name,
+          user.enrolled,
+          user.section,
           user.username,
-          user.enrolled
+          user.is_org_member
         ]
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -107,7 +107,7 @@ class Course < ApplicationRecord
   # export roster students to a CSV file
   def export_students_to_csv
     CSV.generate(headers: true) do |csv|
-      csv << %w[studentId email first_name last_name enrolled section github_username org_member_status]
+      csv << %w[studentId email first_name last_name enrolled section github_username org_status]
 
       roster_students.each do |user|
         csv << [

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -107,9 +107,11 @@ class Course < ApplicationRecord
   # export roster students to a CSV file
   def export_students_to_csv
     CSV.generate(headers: true) do |csv|
-      csv << %w[studentId email first_name last_name enrolled section github_username org_status]
+      csv << %w[studentId email first_name last_name enrolled section github_username org_status teams]
 
       roster_students.each do |user|
+        org_member_status = user.org_membership_type || user.is_org_member
+
         csv << [
           user.perm,
           user.email,
@@ -118,7 +120,8 @@ class Course < ApplicationRecord
           user.enrolled,
           user.section,
           user.username,
-          user.is_org_member
+          org_member_status,
+          user.teams_string
         ]
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -77,7 +77,8 @@ class Course < ApplicationRecord
 
       row["student_id"] = spreadsheet_row[id_index]
       row["email"] = spreadsheet_row[email_index]
-      row["section"] = spreadsheet_row[section_index]
+      row["section"] = spreadsheet_row[section_index] unless section_index.nil?
+
 
       if first_name_index
         row["first_name"] = spreadsheet_row[first_name_index]
@@ -91,7 +92,7 @@ class Course < ApplicationRecord
       next if row.values.all?(&:nil?) # skip empty rows
 
       # check if there is an existing student in the course or create a new one
-      student = roster_students.find_by(perm: row["perm"]) ||
+      student = roster_students.find_by(perm: row["student_id"]) ||
       roster_students.new
 
       student.enrolled = true
@@ -100,7 +101,7 @@ class Course < ApplicationRecord
       student.first_name = row["first_name"]
       student.last_name = row["last_name"]
       student.email = row["email"]
-      student.section = row["section"]
+      student.section = row["section"] unless section_index.nil?
       student.save
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -59,7 +59,7 @@ class Course < ApplicationRecord
     spreadsheet = Roo::Spreadsheet.open(file, extension: ext)
 
     # get index for each param
-    id_index = header_map.index("perm")
+    id_index = header_map.index("student_id")
     email_index = header_map.index("email")
     first_name_index = header_map.index("first_name")
     last_name_index = header_map.index("last_name")
@@ -75,7 +75,7 @@ class Course < ApplicationRecord
 
       row = {} # build dynaimically based on choices
 
-      row["perm"] = spreadsheet_row[id_index]
+      row["student_id"] = spreadsheet_row[id_index]
       row["email"] = spreadsheet_row[email_index]
       row["section"] = spreadsheet_row[section_index]
 
@@ -95,7 +95,8 @@ class Course < ApplicationRecord
       roster_students.new
 
       student.enrolled = true
-      student.perm = row["perm"]
+      # We're changing the outward references to student id, but not renaming the perm column for now
+      student.perm = row["student_id"]
       student.first_name = row["first_name"]
       student.last_name = row["last_name"]
       student.email = row["email"]
@@ -107,7 +108,7 @@ class Course < ApplicationRecord
   # export roster students to a CSV file
   def export_students_to_csv
     CSV.generate(headers: true) do |csv|
-      csv << %w[studentId email first_name last_name enrolled section github_username org_status teams]
+      csv << %w[student_id email first_name last_name enrolled section github_username org_status teams]
 
       roster_students.each do |user|
         org_member_status = user.org_membership_type || user.is_org_member

--- a/app/models/org_team.rb
+++ b/app/models/org_team.rb
@@ -1,6 +1,6 @@
 class OrgTeam < ApplicationRecord
   belongs_to :course
-  has_many :student_team_memberships
+  has_many :student_team_memberships, dependent: :destroy
   has_many :roster_students, through: :student_team_memberships
   has_many :repo_team_contributors
   has_many :github_repos, through: :repo_team_contributors

--- a/app/models/roster_student.rb
+++ b/app/models/roster_student.rb
@@ -20,7 +20,7 @@ class RosterStudent < ApplicationRecord
   # Used when exporting CSV
   def teams_string
     team_str = ""
-    user.org_teams.each do |team|
+    org_teams.each do |team|
       team_str += "#{team.slug}/"
     end
     team_str.delete_suffix!("/") unless team_str.empty?

--- a/app/models/roster_student.rb
+++ b/app/models/roster_student.rb
@@ -16,4 +16,14 @@ class RosterStudent < ApplicationRecord
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  # Used when exporting CSV
+  def teams_string
+    team_str = ""
+    user.org_teams.each do |team|
+      team_str += "#{team.slug}/"
+    end
+    team_str.delete_suffix!("/") unless team_str.empty?
+    team_str
+  end
 end

--- a/app/models/roster_student.rb
+++ b/app/models/roster_student.rb
@@ -23,7 +23,7 @@ class RosterStudent < ApplicationRecord
     org_teams.each do |team|
       team_str += "#{team.slug}/"
     end
-    team_str.delete_suffix!("/") unless team_str.empty?
-    team_str
+    return nil if team_str.empty?
+    team_str.delete_suffix("/")
   end
 end

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -92,7 +92,7 @@
       <thead>
         <tr>
           <th data-sortable="true" data-field="StudentID" data-filter-control="input">Student ID</th>
-          <th data-sortable="true" data-field="FirstName" data-filter-control="input">Name</th>
+          <th data-sortable="true" data-field="Name" data-filter-control="input">Name</th>
           <th data-sortable="true" data-field="Email" data-filter-control="input">Email</th>
           <th data-sortable="true" data-field="Enrolled" data-filter-control="select">Enrolled</th>
           <th data-sortable="true" data-field="Section" data-filter-control="select">Section</th>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -92,8 +92,7 @@
       <thead>
         <tr>
           <th data-sortable="true" data-field="StudentID" data-filter-control="input">Student ID</th>
-          <th data-sortable="true" data-field="FirstName" data-filter-control="input">First name</th>
-          <th data-sortable="true" data-field="LastName" data-filter-control="input">Last name</th>
+          <th data-sortable="true" data-field="FirstName" data-filter-control="input">Name</th>
           <th data-sortable="true" data-field="Email" data-filter-control="input">Email</th>
           <th data-sortable="true" data-field="Enrolled" data-filter-control="select">Enrolled</th>
           <th data-sortable="true" data-field="TA" data-filter-control="select">TA</th>
@@ -104,7 +103,6 @@
           <th data-sortable="true" data-field="OrgMembership" data-filter-control="select">Org Membership</th>
           <th></th>
           <th></th>
-          <th></th>
         </tr>
       </thead>
 
@@ -112,8 +110,7 @@
         <% @course.roster_students.each do |student| %>
           <tr>
             <td><%= student.perm %></td>
-            <td><%= student.first_name %></td>
-            <td><%= student.last_name %></td>
+            <td><%= student.full_name %></td>
             <td><%= student.email %></td>
             <td><%= student.enrolled ? "True" : "False" %></td>
             <td><%= !student.user.nil? && student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
@@ -132,7 +129,6 @@
             <% end %>
               <td><%= student.org_membership_type.present? ? student.org_membership_type : "Non-member" %></td>
             <td><%= link_to 'Show', course_roster_student_path(@course, student) %></td>
-            <td><%= link_to 'Edit', edit_course_roster_student_path(@course, student) %></td>
             <% if can? :destroy, student %>
               <td><%= link_to 'Remove', course_roster_student_path(@course, student), method: :delete, data: { confirm: 'Are you sure?' } %></td>
             <% end %>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -95,6 +95,7 @@
           <th data-sortable="true" data-field="FirstName" data-filter-control="input">Name</th>
           <th data-sortable="true" data-field="Email" data-filter-control="input">Email</th>
           <th data-sortable="true" data-field="Enrolled" data-filter-control="select">Enrolled</th>
+          <th data-sortable="true" data-field="Section" data-filter-control="select">Section</th>
           <th data-sortable="true" data-field="TA" data-filter-control="select">TA</th>
           <% if @course.slack_workspace.present? %>
             <th data-sortable="true" data-field="Slack" data-filter-control="input">Slack</th>
@@ -113,6 +114,7 @@
             <td><%= student.full_name %></td>
             <td><%= student.email %></td>
             <td><%= student.enrolled ? "True" : "False" %></td>
+            <td><%= student.section %></td>
             <td><%= !student.user.nil? && student.user.has_role?(:ta, @course) ? "True" : "False" %></td>
             <% if @course.slack_workspace.present? %>
               <% slack_user = student.slack_user %>

--- a/app/views/courses/roster_students/_form.html.erb
+++ b/app/views/courses/roster_students/_form.html.erb
@@ -33,6 +33,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :section %>
+    <%= form.text_field :section, id: :roster_student_section %>
+  </div>
+
+  <div class="field">
     <br>
     <%= form.radio_button :enrolled, 'true', checked: @roster_student.enrolled %>
     <%= label :enrolled_true, 'Enrolled' %>

--- a/app/views/courses/roster_students/edit.html.erb
+++ b/app/views/courses/roster_students/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Roster Student</h1>
+<h1>Editing <%= @roster_student.full_name %></h1>
 
 <%= render 'form', roster_student: @roster_student %>
 

--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -1,6 +1,4 @@
-<p id="notice"><%= notice %></p>
-
-
+<h2><%= @roster_student.full_name %></h2>
 <dl class="dl-horizontal">
   <dt>Student ID</dt>
   <dd> <%= @roster_student.perm %></dd>
@@ -18,6 +16,14 @@
   <dd><%= link_to @roster_student.email, "mailto:#{@roster_student.email}" %></dd>
   <p></p>
 
+  <dt>Enrolled</dt>
+  <dd><%= @roster_student.enrolled ? "True" : "False" %></dd>
+  <p></p>
+
+  <dt>Section</dt>
+  <dd><%= @roster_student.section %></dd>
+  <p></p>
+
   <dt>GitHub ID</dt>
   <% if @roster_student.username.present? %>
     <dd><%= link_to @roster_student.username, "https://github.com/#{@roster_student.username}", class: "js-github-id" %></dd>
@@ -32,41 +38,61 @@
   <% else %>
     <dd>Unknown</dd>
   <% end %>
-  <p></p>
-
-  <dt>Enrolled</dt>
-  <dd><%= @roster_student.enrolled ? "True" : "False" %></dd>
 
 </dl>
 
 <% unless @roster_student.user.nil? %>
-<p class="repo-list-table">
-  <strong>User Repositories</strong>
-  <table class="table">
-    <thead>
-    <tr>
-      <th>Repository (Student Name)</th>
-      <th>GitHub ID</th>
-      <th>Visibility (Permission Level)</th>
-    </tr>
-    </thead>
-    <% find_org_repos.each do |repo| %>
+
+  <% unless @roster_student.org_teams.empty? %>
+  <p>
+    <strong>Teams</strong>
+    <table class="table">
+      <thead>
       <tr>
-        <td><a href=<%= repo.url %>><%= repo.name %></td>
-        <td></td>
-        <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
+        <th>Name</th>
+        <th>Student Role</th>
       </tr>
-      <% repo.find_contributors.each do |contributor| %>
-        <tr class="leftMargin">
-          <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
-                          course_roster_student_path(@parent, contributor["id"]) %></td>
-          <td><a href="https://github.com/<%= contributor["username"] %>"><%= contributor["username"] %></td>
-          <td><a href="<%= repo.url %>/settings/access"><%= contributor["permission_level"] %></td>
+      </thead>
+      <% @roster_student.student_team_memberships.each do |membership| %>
+        <tr>
+          <td><%= link_to membership.org_team.name, membership.org_team.url %></td>
+          <td><%= membership.role %></td>
         </tr>
       <% end %>
+    </table>
+  </p>
+  <% end %>
+
+  <p class="repo-list-table">
+    <% org_repos = find_org_repos %>
+    <% unless org_repos.empty? %>
+    <strong>Repositories</strong>
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Repository (Student Name)</th>
+        <th>GitHub ID</th>
+        <th>Visibility (Permission Level)</th>
+      </tr>
+      </thead>
+      <% org_repos.each do |repo| %>
+        <tr>
+          <td><a href=<%= repo.url %>><%= repo.name %></td>
+          <td></td>
+          <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
+        </tr>
+        <% repo.find_contributors.each do |contributor| %>
+          <tr class="leftMargin">
+            <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
+                            course_roster_student_path(@parent, contributor["id"]) %></td>
+            <td><a href="https://github.com/<%= contributor["username"] %>"><%= contributor["username"] %></td>
+            <td><a href="<%= repo.url %>/settings/access"><%= contributor["permission_level"] %></td>
+          </tr>
+        <% end %>
+      <% end %>
+    </table>
     <% end %>
-  </table>
-</p>
+  </p>
 
 <% else %>
   <p class="no-repo-list-table"> </p>

--- a/db/migrate/20200403222035_add_section_to_roster_students.rb
+++ b/db/migrate/20200403222035_add_section_to_roster_students.rb
@@ -1,0 +1,5 @@
+class AddSectionToRosterStudents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :roster_students, :section, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200327234145) do
+ActiveRecord::Schema.define(version: 20200403222035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20200327234145) do
     t.boolean "enrolled", default: true
     t.boolean "is_org_member"
     t.string "org_membership_type"
+    t.string "section"
     t.index ["course_id"], name: "index_roster_students_on_course_id"
     t.index ["email", "course_id"], name: "index_roster_students_on_email_and_course_id", unique: true
     t.index ["perm", "course_id"], name: "index_roster_students_on_perm_and_course_id", unique: true

--- a/test/controllers/roster_students_controller_test.rb
+++ b/test/controllers/roster_students_controller_test.rb
@@ -136,7 +136,7 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     )
-    assert_redirected_to course_path(@roster_student.course_id)
+    assert_redirected_to course_roster_student_path(@roster_student.course_id)
   end
 
   test "should destroy roster_student" do
@@ -241,7 +241,7 @@ class RosterStudentsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     )
-    assert_redirected_to course_path(@roster_student.course_id)
+    assert_redirected_to course_roster_student_path(@roster_student.course_id)
   end
 
   test "a TA of one class cannot update roster student for a different class" do

--- a/test/fixtures/files/duplicate_email.csv
+++ b/test/fixtures/files/duplicate_email.csv
@@ -1,4 +1,4 @@
-perm,email,first_name,last_name
+student_id,email,first_name,last_name
 123,peery@umail.ucsb.edu,Hey,Yo
 8425,peery@umail.ucsb.edu,Wesley,Peery
 1234,peery@umail.ucsb.edu,firstname,lastname

--- a/test/fixtures/files/duplicate_perm.csv
+++ b/test/fixtures/files/duplicate_perm.csv
@@ -1,4 +1,4 @@
-perm,email,first_name,last_name
+student_id,email,first_name,last_name
 1234,Hey@email.com,Hey,Yo
 1234,peery@umail.ucsb.edu,Wesley,Peery
 1234,email@email.com,firstname,lastname

--- a/test/fixtures/files/students.csv
+++ b/test/fixtures/files/students.csv
@@ -1,4 +1,4 @@
-perm,email,first_name,last_name
+student_id,email,first_name,last_name
 123,Hey@email.com,Hey,Yo
 8425,peery@umail.ucsb.edu,Wesley,Peery
 1234,email@email.com,firstname,lastname

--- a/test/fixtures/files/students2.csv
+++ b/test/fixtures/files/students2.csv
@@ -1,4 +1,4 @@
-perm,email,first_name,last_name
+student_id,email,first_name,last_name
 123,Hey@email.com,Hey,Yo
 8415,julie@umail.ucsb.edu,Julie,L
 1234,email@email.com,firstname,lastname

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -29,7 +29,7 @@ class CourseTest < ActiveSupport::TestCase
 
     csv_file = fixture_file_upload('files/students.csv')
 
-    csv_header_map = ["perm","email","first_name","last_name"]
+    csv_header_map = ["student_id","email","first_name","last_name"]
     assert_difference('@course.roster_students.where(enrolled: true).count', 2) do
 
       @course.import_students(csv_file,csv_header_map,false)
@@ -41,7 +41,7 @@ class CourseTest < ActiveSupport::TestCase
 
     csv_file = fixture_file_upload('files/students.csv')
 
-    csv_header_map = ["perm","email","first_name","last_name"]
+    csv_header_map = ["student_id","email","first_name","last_name"]
 
     assert_difference('@course.roster_students.where(enrolled: true).count', 1) do
       @course.import_students(csv_file,csv_header_map,true)
@@ -52,8 +52,7 @@ class CourseTest < ActiveSupport::TestCase
   test "download to csv" do
     csv = @course.export_students_to_csv
 
-    #NOTE: The roster_students do not yet have a github username but the exported csv provides a column for it
-    expected_csv = "studentId,email,first_name,last_name,github_username,enrolled\n12345678,wes@email.com,Wes,P,,true\n21345678,tim@email.com,Tim,H,,true\n"
+    expected_csv = "student_id,email,first_name,last_name,enrolled,section,github_username,org_status,teams\n12345678,wes@email.com,Wes,P,true,,,,\n21345678,tim@email.com,Tim,H,true,,,,\n"
     assert_equal csv, expected_csv
   end
 
@@ -61,7 +60,7 @@ class CourseTest < ActiveSupport::TestCase
     csv_file1 = fixture_file_upload('files/students.csv')
     csv_file2 = fixture_file_upload('files/students2.csv')
 
-    csv_header_map = ["perm","email","first_name","last_name"]
+    csv_header_map = ["student_id","email","first_name","last_name"]
     @course.import_students(csv_file1,csv_header_map,true)
 
 
@@ -73,7 +72,7 @@ class CourseTest < ActiveSupport::TestCase
 
   test "roster_students emails for a course should be unique" do
     csv_file = fixture_file_upload("files/duplicate_email.csv")
-    csv_header_map = ["perm","email","first_name","last_name"]
+    csv_header_map = ["student_id","email","first_name","last_name"]
 
     assert_difference('@course.roster_students.where(enrolled: true).count', -1) do
       @course.import_students(csv_file,csv_header_map,true)
@@ -83,7 +82,7 @@ class CourseTest < ActiveSupport::TestCase
 
   test "roster_students perms for a course should be unique" do
     csv_file = fixture_file_upload("files/duplicate_perm.csv")
-    csv_header_map = ["perm","email","first_name","last_name"]
+    csv_header_map = ["student_id","email","first_name","last_name"]
 
     assert_difference('@course.roster_students.where(enrolled: true).count', -1) do
       @course.import_students(csv_file,csv_header_map,true)


### PR DESCRIPTION
This PR implements everything in the following issues:
- Closes #113
- Closes #186
- Closes #201
- Closes #202

As described in those issues, it adds section and team info to the /whois slack command. Additionally, it adds a section field to roster_student (including CSV IO and show/edit/index table display). Finally, org membership status and teams a student is a member of are added to the downloaded CSV.