### PR TITLE
GitHub webhooks integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,4 +98,7 @@ gem 'dotiw'
 gem 'bootstrap-table-rails'
 gem 'jquery-turbolinks'
 
+# TODO: This can be changed to slack-ruby-client, which is a subset of the bot gem features.
 gem 'slack-ruby-bot'
+
+gem 'github_webhook', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,10 @@ GEM
     ffi (1.12.2)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    github_webhook (1.1.1)
+      activesupport (>= 4)
+      rack (>= 1.3)
+      railties (>= 4)
     gli (2.19.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -300,6 +304,7 @@ DEPENDENCIES
   dotenv-rails
   dotiw
   font-awesome-rails
+  github_webhook (~> 1.1)
   jbuilder (~> 2.5)
   jquery-rails
   jquery-turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     ffi (1.12.2)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
-    github_webhook (1.1.1)
+    github_webhook (1.1.2)
       activesupport (>= 4)
       rack (>= 1.3)
       railties (>= 4)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -37,7 +37,7 @@ class AdminController < ApplicationController
       job_name = params[:job_name]
       job = admin_job_list.find { |job| job.job_short_name == job_name }
       job.perform_async
-      redirect_to admin_dashboard_path
+      redirect_to dashboard_admin_path
     end
 
     def rate_limits

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -4,7 +4,6 @@ module Courses
     load_resource :course
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_user!
-    skip_before_action :authenticate_github_request!
 
     def github_organization(payload)
       case payload[:action]
@@ -105,7 +104,7 @@ module Courses
       when "removed_from_repository"
         return if existing_team_record.nil?
         contributor_record = RepoTeamContributor.where(org_team: existing_team_record)
-            .includes(:github_repo).references(:github_repo).merge(GithubRepo.where(repo_id: payload[:repository][:node_id])).first
+            .includes(:github_repo).references(:github_repo).merge(GithubRepo.where(repo_id: payload[:repository][:id])).first
         contributor_record.try(:destroy)
       else
         return

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -8,18 +8,18 @@ module Courses
     def github_organization(payload)
       case payload[:action]
       when "member_invited"
-        student = @course.student_for_username(payload[:invitation][:login])
+        student = @course.student_for_uid(payload[:invitation][:id])
         return if student.nil?
         student.org_membership_type = "Invited"
         student.save
       when "member_added"
-        student = @course.student_for_username(payload[:membership][:user][:login])
+        student = @course.student_for_uid(payload[:membership][:user][:id])
         return if student.nil?
         student.is_org_member = true
         student.org_membership_type = payload[:membership][:role].capitalize
         student.save
       when "member_removed"
-        student = @course.student_for_username(payload[:membership][:user][:login])
+        student = @course.student_for_uid(payload[:membership][:user][:id])
         return if student.nil?
         student.is_org_member = false
         student.org_membership_type = nil
@@ -36,23 +36,23 @@ module Courses
       case payload[:action]
       when "created"
       when "deleted"
-        repo_to_delete = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        repo_to_delete = GithubRepo.where(course: @course, repo_id: payload[:repository][:id]).first
         return if repo_to_delete.nil?
         repo_to_delete.destroy
       when "edited"
         # Nothing to do here for now
       when "renamed"
-        repo_to_rename = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        repo_to_rename = GithubRepo.where(course: @course, repo_id: payload[:repository][:id]).first
         return if repo_to_rename.nil?
         repo_to_rename.name = payload[:repository][:name]
         repo_to_rename.full_name = payload[:repository][:full_name]
         repo_to_rename.save
       when "publicized"
-        repo_to_modify = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        repo_to_modify = GithubRepo.where(course: @course, repo_id: payload[:repository][:id]).first
         repo_to_modify.visibility = "public"
         repo_to_modify.save
       when "privatized"
-        repo_to_modify = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        repo_to_modify = GithubRepo.where(course: @course, repo_id: payload[:repository][:id]).first
         repo_to_modify.visibility = "private"
         repo_to_modify.save
       else
@@ -61,10 +61,27 @@ module Courses
     end
 
     def github_member(payload)
+      user = User.where(uid: payload[:member][:id])
+      repository = GithubRepo.where(repo_id: payload[:repository][:id])
+      return if user.nil? || repository.nil?
+      existing_contributor_record = RepoContributor.where(github_repo: repository, user: user).first
       case payload[:action]
+        # GitHub's API has some kind of hilarious prank where this webhook won't give you the user's permission on the repository.
+        # The kicker? When you change a user's repo permission it sends a webhook. But that webhook only contains
+        # the OLD permission. Meaning: if you change a user's permission from read to write, it'll send you a webhook that basically says
+        # "that user used to have read permission". I think there's a quantum superposition joke in here, but I'll have to workshop that some more.
+        # Anyway, I filed a bug report but in the meantime I'm just having this webhook make an API request to get the permission level.
       when "added"
+        existing_contributor_record.destroy if existing_contributor_record.present?
+        permission_level = get_user_repo_permission(payload[:repository][:name], user.uid)
+        RepoContributor.create(user: user, github_repo: repository, permission_level: permission_level)
       when "edited"
+        return if existing_contributor_record.nil?
+        existing_contributor_record.permission_level = get_user_repo_permission(payload[:repository][:name], user.uid)
+        existing_contributor_record.save
       when "removed"
+        return if existing_contributor_record.nil?
+        existing_contributor_record.destroy
       else
         return
       end
@@ -91,8 +108,30 @@ module Courses
       end
     end
 
+    private
     def webhook_secret(payload)
       ENV['GITHUB_WEBHOOK_SECRET']
+    end
+
+    def get_user_repo_permission(repo_name, user_id)
+      response = github_machine_user.post '/graphql', { query: user_repo_permission_query(repo_name) }.to_json
+      collaborator = response.data.repository.collaborators.edges
+      user_collaborator = contributors.find { |c| c.node.databaseId == user_id }
+      return nil if user_collaborator.nil?
+      user_collaborator.permission.capitalize
+    end
+
+    def user_repo_permission_query(repo_name)
+      <<-GRAPHQL
+        query { 
+          repository(owner:"#{@course.course_organization}",name:"#{repo_name}") {
+            collaborators {
+              edges {
+                permission
+                node {
+                  databaseId
+        } } } } }
+      GRAPHQL
     end
   end
 end

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -63,8 +63,8 @@ module Courses
     end
 
     def github_member(payload)
-      user = User.where(uid: payload[:member][:id])
-      repository = GithubRepo.where(repo_id: payload[:repository][:id])
+      user = User.where(uid: payload[:member][:id]).first
+      repository = GithubRepo.where(repo_id: payload[:repository][:id]).first
       return if user.nil? || repository.nil?
       existing_contributor_record = RepoContributor.where(github_repo: repository, user: user).first
       case payload[:action]
@@ -136,8 +136,8 @@ module Courses
 
     def get_user_repo_permission(repo_name, user_id)
       response = github_machine_user.post '/graphql', { query: user_repo_permission_query(repo_name) }.to_json
-      collaborator = response.data.repository.collaborators.edges
-      user_collaborator = contributors.find { |c| c.node.databaseId == user_id }
+      collaborators = response.data.repository.collaborators.edges
+      user_collaborator = collaborators.find { |c| c.node.databaseId == user_id }
       return nil if user_collaborator.nil?
       user_collaborator.permission.capitalize
     end

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -5,13 +5,12 @@ module Courses
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_user!
 
-    def github_push(payload)
+    def github_team(payload)
 
     end
 
-    def verify_signature(payload_body)
-      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['SECRET_TOKEN'], payload_body)
-      return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
+    def webhook_secret(payload)
+      ENV['GITHUB_WEBHOOK_SECRET']
     end
   end
 end

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -8,10 +8,24 @@ module Courses
     def github_organization(payload)
       case payload[:action]
       when "member_invited"
+        student = @course.roster_students.select { |st| st.username == payload[:invitation][:login] }.first
+        return if student.nil?
+        student.org_membership_type = "Invited"
+        student.save
       when "member_added"
+        student = @course.roster_students.select { |st| st.username == payload[:membership][:user][:login] }.first
+        return if student.nil?
+        student.is_org_member = true
+        student.org_membership_type = payload[:membership][:role].capitalize
+        student.save
       when "member_removed"
+        student = @course.roster_students.select { |st| st.username == payload[:membership][:user][:login] }.first
+        student.is_org_member = false
+        student.org_membership_type = nil
+        student.save
       when "renamed"
-      when "deleted"
+        @course.course_organization = payload[:organization][:login]
+        @course.save
       else
         return
       end

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -4,6 +4,7 @@ module Courses
     load_resource :course
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_user!
+    skip_before_action :authenticate_github_request!
 
     def github_organization(payload)
       case payload[:action]
@@ -179,7 +180,7 @@ module Courses
     end
 
     def upsert_team_repo_permissions(team, payload)
-      repo_record = GithubRepo.where(repo_id: payload[:repository][:id])
+      repo_record = GithubRepo.where(repo_id: payload[:repository][:id]).first
       return if repo_record.nil?
       contributor_record = RepoTeamContributor.where(org_team: team, github_repo: repo_record).first_or_initialize
       repo_permissions = payload[:repository][:permissions]

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -92,7 +92,6 @@ module Courses
       when "created"
         existing_team_record.try(:destroy)
         team = OrgTeam.create(name: team_info[:name], slug: team_info[:slug], url: team_info[:html_url], team_id: team_info[:node_id], course: @course)
-        add_student_to_team_if_found(team, payload)
       when "deleted"
         existing_team_record.try(:destroy)
       when "edited"

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -104,7 +104,7 @@ module Courses
       when "removed_from_repository"
         return if existing_team_record.nil?
         contributor_record = RepoTeamContributor.where(org_team: existing_team_record)
-            .includes(:github_repo).references(:github_repo).merge(GithubRepo.where(repo_id: payload[:repository][:node_id]))
+            .includes(:github_repo).references(:github_repo).merge(GithubRepo.where(repo_id: payload[:repository][:node_id])).first
         contributor_record.try(:destroy)
       else
         return
@@ -157,7 +157,7 @@ module Courses
       return if student_member.nil?
       response = github_machine_user.post '/graphql', { query: team_member_role_query(team.slug) }.to_json
       team_members = response.data.organization.team.members.edges
-      found_member = team_members.find { |m| m.node.databaseId == student_member.user.uid }
+      found_member = team_members.find { |m| m.node.databaseId == student_member.user.uid.to_i }
       return if found_member.nil?
       membership = StudentTeamMembership.where(org_team: team, roster_student: student_member).first_or_initialize
       membership.role = found_member.role.downcase

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -1,0 +1,17 @@
+module Courses
+  class GithubWebhooksController < ApplicationController
+    include GithubWebhook::Processor
+    load_resource :course
+    skip_before_action :verify_authenticity_token
+    skip_before_action :authenticate_user!
+
+    def github_push(payload)
+
+    end
+
+    def verify_signature(payload_body)
+      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['SECRET_TOKEN'], payload_body)
+      return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
+    end
+  end
+end

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -5,8 +5,60 @@ module Courses
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_user!
 
-    def github_team(payload)
+    def github_organization(payload)
+      case payload[:action]
+      when "member_invited"
+      when "member_added"
+      when "member_removed"
+      when "renamed"
+      when "deleted"
+      else
+        return
+      end
+    end
 
+    def github_repository(payload)
+      case payload[:action]
+      when "created"
+      when "deleted"
+      when "edited"
+      when "renamed"
+      when "publicized"
+      when "privatized"
+      else
+        return
+      end
+    end
+
+    def github_member(payload)
+      case payload[:action]
+      when "added"
+      when "edited"
+      when "removed"
+      else
+        return
+      end
+    end
+
+    def github_team(payload)
+      case payload[:action]
+      when "created"
+      when "deleted"
+      when "edited"
+      when "added_to_repository"
+      when "removed_from_repository"
+      else
+        return
+      end
+    end
+
+    def github_membership(payload)
+      case payload[:action]
+      when "added"
+      when "removed"
+      else
+        return
+      end
     end
 
     def webhook_secret(payload)

--- a/app/controllers/courses/github_webhooks_controller.rb
+++ b/app/controllers/courses/github_webhooks_controller.rb
@@ -8,18 +8,19 @@ module Courses
     def github_organization(payload)
       case payload[:action]
       when "member_invited"
-        student = @course.roster_students.select { |st| st.username == payload[:invitation][:login] }.first
+        student = @course.student_for_username(payload[:invitation][:login])
         return if student.nil?
         student.org_membership_type = "Invited"
         student.save
       when "member_added"
-        student = @course.roster_students.select { |st| st.username == payload[:membership][:user][:login] }.first
+        student = @course.student_for_username(payload[:membership][:user][:login])
         return if student.nil?
         student.is_org_member = true
         student.org_membership_type = payload[:membership][:role].capitalize
         student.save
       when "member_removed"
-        student = @course.roster_students.select { |st| st.username == payload[:membership][:user][:login] }.first
+        student = @course.student_for_username(payload[:membership][:user][:login])
+        return if student.nil?
         student.is_org_member = false
         student.org_membership_type = nil
         student.save
@@ -35,10 +36,25 @@ module Courses
       case payload[:action]
       when "created"
       when "deleted"
+        repo_to_delete = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        return if repo_to_delete.nil?
+        repo_to_delete.destroy
       when "edited"
+        # Nothing to do here for now
       when "renamed"
+        repo_to_rename = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        return if repo_to_rename.nil?
+        repo_to_rename.name = payload[:repository][:name]
+        repo_to_rename.full_name = payload[:repository][:full_name]
+        repo_to_rename.save
       when "publicized"
+        repo_to_modify = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        repo_to_modify.visibility = "public"
+        repo_to_modify.save
       when "privatized"
+        repo_to_modify = GithubRepo.where(course_id: @course.id, repo_id: payload[:repository][:id]).first
+        repo_to_modify.visibility = "private"
+        repo_to_modify.save
       else
         return
       end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -48,6 +48,8 @@ class CoursesController < ApplicationController
   # PATCH/PUT /courses/1
   # PATCH/PUT /courses/1.json
   def update
+    # Allows the webhook handler in the model to get the full url path. Kind of a hack, we can maybe accomplish this better using env variables
+    Rails.application.routes.default_url_options[:host] = request.base_url
     respond_to do |format|
       if @course.update(course_params)
         format.html { redirect_to @course, notice: 'Course was successfully updated.' }
@@ -103,11 +105,6 @@ class CoursesController < ApplicationController
       redirect_to courses_path, alert: message
     end
   end
-
-  def is_org_member?(username)
-    machine_user.organization_member?(@course.course_organization, username)
-  end
-  helper_method :is_org_member?
 
   def jobs
     @course = Course.find(params[:course_id])

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -34,7 +34,7 @@ class CoursesController < ApplicationController
         add_instructor(@course.id)
         @course.accept_invite_to_course_org
         if @course.github_webhooks_enabled
-
+          @course.add_webhook_to_course_org
         end
         format.html { redirect_to @course, notice: 'Course was successfully created.' }
         format.json { render :show, status: :created, location: @course }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -33,6 +33,9 @@ class CoursesController < ApplicationController
       if @course.save
         add_instructor(@course.id)
         @course.accept_invite_to_course_org
+        if @course.github_webhooks_enabled
+
+        end
         format.html { redirect_to @course, notice: 'Course was successfully created.' }
         format.json { render :show, status: :created, location: @course }
       else

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -160,7 +160,7 @@ class CoursesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def course_params
-      params.require(:course).permit(:name,:course_organization,:hidden, :search)
+      params.require(:course).permit(:name,:course_organization,:hidden, :search, :github_webhooks_enabled)
     end
 
     def add_instructor(id)

--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -1,3 +1,0 @@
-class GithubWebhooksController < ApplicationController
-  include GithubWebhook::Processor
-end

--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -1,0 +1,3 @@
+class GithubWebhooksController < ApplicationController
+  include GithubWebhook::Processor
+end

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -48,7 +48,7 @@ module Slack
 
     private
     def verify_request
-      authorize! :slack_command, SlackWorkspace\
+      authorize! :slack_command, SlackWorkspace
       # Credit: https://github.com/slack-ruby/slack-ruby-client/issues/238#issuecomment-442981145
       signing_secret = ENV['SLACK_SIGNING_SECRET']
       version_number = 'v0' # always v0 for now

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -3,9 +3,9 @@ module Slack
     # TODO: Set up Slack global request configuration to validate signing secret. We can't check CSRF token, so it's all the more important
     skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_user!
+    before_action :verify_request
 
     def whois
-      authorize! :slack_command, SlackWorkspace
       workspace = SlackWorkspace.find_by_team_id(params[:team_id])
       if workspace.nil?
         render json: { :text => "Associated workspace could not be found in the database." }
@@ -43,6 +43,32 @@ module Slack
         puts command_output
         command_output.empty? ? command_output = "No students found for the provided user(s)." : command_output.delete_suffix!("\n")
         render json: { :text => command_output }
+      end
+    end
+
+    private
+    def verify_request
+      authorize! :slack_command, SlackWorkspace\
+      # Credit: https://github.com/slack-ruby/slack-ruby-client/issues/238#issuecomment-442981145
+      signing_secret = ENV['SLACK_SIGNING_SECRET']
+      version_number = 'v0' # always v0 for now
+      timestamp = request.headers['X-Slack-Request-Timestamp']
+      raw_body = request.body.read # raw body JSON string
+
+      if Time.at(timestamp.to_i) < 5.minutes.ago
+        # could be a replay attack
+        render nothing: true, status: :bad_request
+        return
+      end
+
+      sig_basestring = [version_number, timestamp, raw_body].join(':')
+      digest = OpenSSL::Digest::SHA256.new
+      hex_hash = OpenSSL::HMAC.hexdigest(digest, signing_secret, sig_basestring)
+      computed_signature = [version_number, hex_hash].join('=')
+      slack_signature = request.headers['X-Slack-Signature']
+
+      if computed_signature != slack_signature
+        render nothing: true, status: :unauthorized
       end
     end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def github_machine_user
+    Octokit_Wrapper::Octokit_Wrapper.machine_user
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,9 @@ class Course < ApplicationRecord
   has_many :github_repos, dependent: :destroy
   has_many :org_teams, dependent: :destroy
   has_one :slack_workspace, dependent: :destroy
+  has_one :github_webhook, dependent: :destroy
+
+  before_save :update_github_webhook, if: :will_save_change_to_github_webhooks_enabled?
 
   resourcify
 
@@ -33,11 +36,52 @@ class Course < ApplicationRecord
     end
   end
 
-  def add_webhook_to_course_org(user)
+  def update_github_webhook
+    if github_webhooks_enabled
+      remove_webhook_from_course_org
+    else
+      add_webhook_to_course_org
+    end
+  end
+
+  def add_webhook_to_course_org
     # Register course webhook
-    github_machine_user.create_org_hook(@course.course_organization, {
-        :url => course_github_webhooks_url
-    })
+    begin
+      response = github_machine_user.create_org_hook(@course.course_organization, {
+          :url => course_github_webhooks_url,
+          :content_type => 'json',
+          :secret => ENV['GITHUB_WEBHOOK_SECRET']
+        }, {
+          :events => ['repository', 'member', 'team', 'membership', 'organization'],
+          :active => true
+      })
+      GithubWebhook.create(hook_id: response.id, hook_url: response.url, course: self)
+    rescue Octokit::Error => e
+      self.github_webhooks_enabled = false
+      self.save
+      error = "Failed to add webhook to course organization."
+      if ENV['DEBUG_VERBOSE'] && ENV['DEBUG_VERBOSE'] == 1
+        error += e.to_s
+      end
+      puts e
+      errors.add(:base, error)
+    end
+  end
+
+  def remove_webhook_from_course_org
+    begin
+      github_machine_user.remove_org_hook(course_organization, github_webhook.hook_id)
+      github_webhook.destroy
+      self.github_webhooks_enabled = false
+      self.save
+    rescue Octokit::Error => e
+      error = "Failed to remove webhook from course organization."
+      if ENV['DEBUG_VERBOSE'] && ENV['DEBUG_VERBOSE'] == 1
+        error += e.to_s
+      end
+      puts e
+      errors.add(:base, error)
+    end
   end
 
   def check_course_org_exists

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,6 +14,7 @@ class Course < ApplicationRecord
   has_one :org_webhook, dependent: :destroy
 
   before_save :update_org_webhook, if: :will_save_change_to_github_webhooks_enabled?
+  before_destroy :remove_webhook_from_course_org
 
   resourcify
 
@@ -25,6 +26,11 @@ class Course < ApplicationRecord
       @no_org = true
       @org = nil
     end
+  end
+
+  def student_for_username(username)
+    # Because this is a pure SQL query rather than a bunch of Ruby array operations, it is several times faster than previous approaches.
+    RosterStudent.where(course_id: self.id).includes(:user).references(:user).merge(User.where(username: username)).first
   end
 
   def accept_invite_to_course_org

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -30,7 +30,7 @@ class Course < ApplicationRecord
 
   def student_for_uid(uid)
     # Because this is a pure SQL query rather than a bunch of Ruby array operations, it is several times faster than previous approaches.
-    RosterStudent.where(course_id: self.id).includes(:user).references(:user).merge(User.where(uid: uid)).first
+    RosterStudent.where(course_id: self.id).includes(:user).references(:user).merge(User.where(uid: uid.to_s)).first
   end
 
   def accept_invite_to_course_org

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -56,7 +56,6 @@ class Course < ApplicationRecord
           :events => ['repository', 'member', 'team', 'membership', 'organization'],
           :active => true
       })
-      binding.pry
       OrgWebhook.create(hook_id: response.id, hook_url: response.url, course: self)
     rescue Octokit::Error => e
       self.github_webhooks_enabled = false
@@ -71,7 +70,8 @@ class Course < ApplicationRecord
 
   def remove_webhook_from_course_org
     begin
-      github_machine_user.remove_org_hook(course_organization, github_webhook.hook_id)
+      return if org_webhook.nil?
+      github_machine_user.remove_org_hook(course_organization, org_webhook.hook_id)
       org_webhook.destroy
     rescue Octokit::Error => e
       error = "Failed to remove webhook from course organization."

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -28,9 +28,9 @@ class Course < ApplicationRecord
     end
   end
 
-  def student_for_username(username)
+  def student_for_uid(uid)
     # Because this is a pure SQL query rather than a bunch of Ruby array operations, it is several times faster than previous approaches.
-    RosterStudent.where(course_id: self.id).includes(:user).references(:user).merge(User.where(username: username)).first
+    RosterStudent.where(course_id: self.id).includes(:user).references(:user).merge(User.where(uid: uid)).first
   end
 
   def accept_invite_to_course_org

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -5,6 +5,11 @@ class GithubRepo < ApplicationRecord
   has_many :repo_team_contributors, dependent: :destroy
   has_many :org_teams, through: :repo_team_contributors
 
+  # Note: most (if not all) of the GitHub-related objects store a unique identifier for that object assigned by GitHub.
+  # These are, by our convention, something like #repo_id, #hook_id, #team_id, etc.
+  # For all but repositories, we use the "node_id" string provided by GitHub to fill this field. HOWEVER, for repositories (repo_id),
+  # because GitHub sometimes omits the node_id for repos, we use the GitHub "id" integer (in GraphQL responses, this is called the "databaseId").
+
   def find_contributors
     # This query gets certain information about a student, their user, and relationship to the repository in question.
     # It is written in raw SQL because it would take several queries using Rails syntax.

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -7,7 +7,7 @@ class GithubRepo < ApplicationRecord
 
   # Note: most (if not all) of the GitHub-related objects store a unique identifier for that object assigned by GitHub.
   # These are, by our convention, something like #repo_id, #hook_id, #team_id, etc.
-  # For all but repositories, we use the "node_id" string provided by GitHub to fill this field. HOWEVER, for repositories (repo_id),
+  # For all but repositories and users (uid), we use the "node_id" string provided by GitHub to fill this field. HOWEVER, for repositories (repo_id),
   # because GitHub sometimes omits the node_id for repos, we use the GitHub "id" integer (in GraphQL responses, this is called the "databaseId").
 
   def find_contributors

--- a/app/models/github_webhook.rb
+++ b/app/models/github_webhook.rb
@@ -1,3 +1,0 @@
-class GithubWebhook < ApplicationRecord
-  belongs_to :course
-end

--- a/app/models/github_webhook.rb
+++ b/app/models/github_webhook.rb
@@ -1,0 +1,3 @@
+class GithubWebhook < ApplicationRecord
+  belongs_to :course
+end

--- a/app/models/org_webhook.rb
+++ b/app/models/org_webhook.rb
@@ -1,0 +1,3 @@
+class OrgWebhook < ApplicationRecord
+  belongs_to :course
+end

--- a/app/models/student_team_membership.rb
+++ b/app/models/student_team_membership.rb
@@ -1,4 +1,10 @@
 class StudentTeamMembership < ApplicationRecord
   belongs_to :org_team
   belongs_to :roster_student
+  validate :same_course?
+
+  private
+  def same_course?
+    org_team.course_id == roster_student.course_id
+  end
 end

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -51,7 +51,7 @@
         <tr>
           <td><span class="job_name" data-toggle="tooltip" title = "<%= job.job_description %>"><%= job.job_name %></span></td>
           <td><%= job.last_run %></td>
-          <td><%= link_to 'Run Job', admin_run_admin_job_path(job_name: job.job_short_name),
+          <td><%= link_to 'Run Job', run_admin_job_admin_path(job_name: job.job_short_name),
                           method: :post, data: { confirm: job.confirmation_dialog } %></td>
         </tr>
       <% end %>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -22,6 +22,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :github_webhooks_enabled %>
+    <%= form.check_box :github_webhooks_enabled, id: :course_github_webhooks_enabled %>
+  </div>
+
+  <div class="field">
     <%= form.label :hidden %>
     <%= form.check_box :hidden %>
   </div>

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -8,5 +8,5 @@
 <% end %>
 
 <% if can? :manage, :all %>
-  <li><%= nav_link "Admin", admin_dashboard_path %></li>
+  <li><%= nav_link "Admin", dashboard_admin_path %></li>
 <% end %>

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -4,7 +4,7 @@
   <% if current_user.has_role? :admin %>
     <h1> Welcome Admin </h1>
     <p> Proceed to the courses page to manage classes or to the users page to manage users </p>
-    <p><%= link_to "Admin Dashboard", admin_dashboard_path %></p>
+    <p><%= link_to "Admin Dashboard", dashboard_admin_path %></p>
   <p>Note: You can manage a class with a blue name</p>
     
   <% elsif current_user.has_role? :instructor %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,10 @@ Rails.application.routes.draw do
         get :create_teams
         post :generate_teams
       end
+
+      resource :github_webhooks, :only => [:create], :defaults => { :format => :json } do
+
+      end
       # While this is somewhat frowned upon in Rails convention, I refuse to name the controller "SlacksController"
       resource :slack, :controller => 'slack'
     end
@@ -51,10 +55,6 @@ Rails.application.routes.draw do
   resource :admin, :controller => 'admin', :only => [] do
     get :dashboard
     post :run_admin_job
-  end
-
-  resource :github_webhooks, :only => [:create], :defaults => { :format => :json } do
-
   end
 
   # home page routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,12 +26,10 @@ Rails.application.routes.draw do
         end
       end
       resource :teams do
-        collection do
-          get :create_repos
-          post :generate_repos
-          get :create_teams
-          post :generate_teams
-        end
+        get :create_repos
+        post :generate_repos
+        get :create_teams
+        post :generate_teams
       end
       # While this is somewhat frowned upon in Rails convention, I refuse to name the controller "SlacksController"
       resource :slack, :controller => 'slack'
@@ -50,8 +48,14 @@ Rails.application.routes.draw do
   resources :users
 
   # Admin management dashboard
-  match 'admin/dashboard' => 'admin#dashboard', :via => :get
-  match 'admin/run_admin_job' => 'admin#run_admin_job', :via => :post
+  resource :admin, :controller => 'admin', :only => [] do
+    get :dashboard
+    post :run_admin_job
+  end
+
+  resource :github_webhooks, :only => [:create], :defaults => { :format => :json } do
+
+  end
 
   # home page routes
   resources :visitors # NOTE that this defines a number of unused routes that would be good to remove for security

--- a/db/migrate/20200405063917_add_github_webhooks_enabled_to_courses.rb
+++ b/db/migrate/20200405063917_add_github_webhooks_enabled_to_courses.rb
@@ -1,0 +1,5 @@
+class AddGithubWebhooksEnabledToCourses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :courses, :github_webhooks_enabled, :boolean
+  end
+end

--- a/db/migrate/20200405072640_create_github_webhooks.rb
+++ b/db/migrate/20200405072640_create_github_webhooks.rb
@@ -1,6 +1,6 @@
 class CreateGithubWebhooks < ActiveRecord::Migration[5.1]
   def change
-    create_table :github_webhooks do |t|
+    create_table :org_webhooks do |t|
       t.integer :hook_id
       t.belongs_to :course, foreign_key: true
       t.string :hook_url

--- a/db/migrate/20200405072640_create_github_webhooks.rb
+++ b/db/migrate/20200405072640_create_github_webhooks.rb
@@ -1,0 +1,9 @@
+class CreateGithubWebhooks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :github_webhooks do |t|
+      t.integer :hook_id
+      t.belongs_to :course, foreign_key: true
+      t.string :hook_url
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200405063917) do
+ActiveRecord::Schema.define(version: 20200405072640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,13 @@ ActiveRecord::Schema.define(version: 20200405063917) do
     t.string "full_name"
     t.string "visibility"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
+  end
+
+  create_table "github_webhooks", force: :cascade do |t|
+    t.integer "hook_id"
+    t.bigint "course_id"
+    t.string "hook_url"
+    t.index ["course_id"], name: "index_github_webhooks_on_course_id"
   end
 
   create_table "org_teams", force: :cascade do |t|
@@ -169,6 +176,7 @@ ActiveRecord::Schema.define(version: 20200405063917) do
 
   add_foreign_key "completed_jobs", "courses"
   add_foreign_key "github_repos", "courses"
+  add_foreign_key "github_webhooks", "courses"
   add_foreign_key "roster_students", "courses"
   add_foreign_key "roster_students", "users"
   add_foreign_key "slack_users", "slack_workspaces"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,13 +47,6 @@ ActiveRecord::Schema.define(version: 20200405072640) do
     t.index ["course_id"], name: "index_github_repos_on_course_id"
   end
 
-  create_table "github_webhooks", force: :cascade do |t|
-    t.integer "hook_id"
-    t.bigint "course_id"
-    t.string "hook_url"
-    t.index ["course_id"], name: "index_github_webhooks_on_course_id"
-  end
-
   create_table "org_teams", force: :cascade do |t|
     t.string "name"
     t.string "url"
@@ -63,6 +56,13 @@ ActiveRecord::Schema.define(version: 20200405072640) do
     t.string "team_id"
     t.string "slug"
     t.index ["course_id"], name: "index_org_teams_on_course_id"
+  end
+
+  create_table "org_webhooks", force: :cascade do |t|
+    t.integer "hook_id"
+    t.bigint "course_id"
+    t.string "hook_url"
+    t.index ["course_id"], name: "index_org_webhooks_on_course_id"
   end
 
   create_table "repo_contributors", force: :cascade do |t|
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define(version: 20200405072640) do
 
   add_foreign_key "completed_jobs", "courses"
   add_foreign_key "github_repos", "courses"
-  add_foreign_key "github_webhooks", "courses"
+  add_foreign_key "org_webhooks", "courses"
   add_foreign_key "roster_students", "courses"
   add_foreign_key "roster_students", "users"
   add_foreign_key "slack_users", "slack_workspaces"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200403222035) do
+ActiveRecord::Schema.define(version: 20200405063917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20200403222035) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "hidden"
+    t.boolean "github_webhooks_enabled"
   end
 
   create_table "github_repos", force: :cascade do |t|

--- a/dotenv.example
+++ b/dotenv.example
@@ -17,6 +17,8 @@ OMNIAUTH_PROVIDER_SECRET=<your omniauth provider secret>
 MACHINE_USER_NAME=<your machine user's name>
 MACHINE_USER_KEY=<your machine user's key>
 
+GITHUB_WEBHOOK_SECRET=
+
 # This can be any arbitrary value; it is used for cryptographic security
 DEVISE_SECRET_KEY=<a random alphanumeric string used by devise to salt its sessions>
 

--- a/lib/Octokit_Wrapper.rb
+++ b/lib/Octokit_Wrapper.rb
@@ -5,7 +5,7 @@ module Octokit_Wrapper
     end
 
     def self.session_user(token)
-      Octokit_Wrapper.user_with(token)
+      user_with(token)
     end
 
     def self.user_with(token)


### PR DESCRIPTION
This closes #206, closes #207, closes #208, closes #222, and closes #209.

It implements webhook integration for courses for all the purposes that GitHub-related jobs currently serve (and with the added benefit of deleting data when it is deleted on GitHub). Webhooks are added to a course by checking the "Enable GitHub webhooks" box on the course edit/create page. 

I don't have time to fully write everything up right now but I figured I'd leave this here because it's a lot of code to review so we can merge it during our thursday meeting.