### PR TITLE
Added course navigation bar and various other course UI tweaks

### DIFF
--- a/app/controllers/courses/org_teams_controller.rb
+++ b/app/controllers/courses/org_teams_controller.rb
@@ -4,6 +4,7 @@ module Courses
   class OrgTeamsController < ApplicationController
     before_action :load_parent
     load_and_authorize_resource :course
+    layout 'courses'
 
     def index
       @teams = @parent.org_teams

--- a/app/controllers/courses/project_teams_controller.rb
+++ b/app/controllers/courses/project_teams_controller.rb
@@ -1,5 +1,6 @@
 module Courses
   class ProjectTeamsController < ApplicationController
+    layout 'courses'
     load_and_authorize_resource :course
 
     def index

--- a/app/controllers/courses/roster_students_controller.rb
+++ b/app/controllers/courses/roster_students_controller.rb
@@ -5,6 +5,7 @@ require 'Octokit_Wrapper'
 
 module Courses
   class RosterStudentsController < ApplicationController
+    layout 'courses'
     before_action :load_parent
     before_action :set_roster_student, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/courses/slack_controller.rb
+++ b/app/controllers/courses/slack_controller.rb
@@ -1,18 +1,20 @@
 module Courses
   class SlackController < ApplicationController
+    layout 'courses'
+    load_and_authorize_resource :course
+
     def show
-      @parent = Course.find(params[:course_id])
-      @workspace = @parent.slack_workspace
+      @slack_workspace = @course.slack_workspace
     end
 
     def destroy
-      @parent = Course.find(params[:course_id])
-      if @parent.slack_workspace.present?
-        @parent.slack_workspace.destroy
-        @parent.save
-        redirect_to course_slack_path(@parent), notice: "Workspace successfully removed from course."
+      @course = Course.find(params[:course_id])
+      if @course.slack_workspace.present?
+        @course.slack_workspace.destroy
+        @course.save
+        redirect_to course_slack_path(@course), notice: "Workspace successfully removed from course."
       else
-        redirect_to course_slack_path(@parent), alert: "Workspace to delete could not be found."
+        redirect_to course_slack_path(@course), alert: "Workspace to delete could not be found."
       end
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -3,7 +3,7 @@ require 'Octokit_Wrapper'
 class CoursesController < ApplicationController
   before_action :set_course, only: [:show, :edit, :update, :destroy]
   load_and_authorize_resource
-
+  layout 'courses', except: :index
 
   # GET /courses
   # GET /courses.json

--- a/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
+++ b/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
@@ -1,18 +1,48 @@
 import React, {Component, Fragment} from 'react';
 import * as PropTypes from 'prop-types';
+import {Row, Col, MenuItem, Tab, Nav, NavItem, NavDropdown, Button} from "react-bootstrap";
 
 class CourseNavBar extends Component {
+    currentActiveTab = () => {
+        // Captures path after the course index.
+        // E.g. for path '/courses/1/project_teams/new', this captures 'project_teams'.
+        const pathMatchRegex = new RegExp('\/courses\/[0-9]*/([^/]*)', 'i');
+        const coursePathMatches = pathMatchRegex.exec(this.props.current_path);
+        if (coursePathMatches == null || coursePathMatches.length <= 1) {
+            return 'roster';
+        }
+        return coursePathMatches[1];
+    }
+
     render() {
+        const activeTabKey = this.currentActiveTab();
         return (
             <Fragment>
-
+                <Nav bsStyle="tabs" activeKey={activeTabKey}>
+                    <NavItem eventKey="roster" href={this.props.roster_path}>Students</NavItem>
+                    <NavDropdown title="Teams">
+                        <MenuItem eventKey="project_teams" href={this.props.project_teams_path}>Project Teams</MenuItem>
+                        <MenuItem eventKey="org_teams" href={this.props.org_teams_path}>GitHub Teams</MenuItem>
+                    </NavDropdown>
+                    <NavItem eventKey="repos" href={this.props.repos_path}>Repositories</NavItem>
+                    <NavItem eventKey="slack" href={this.props.slack_path}>Slack</NavItem>
+                    <NavItem eventKey="jobs" href={this.props.jobs_path}>Jobs</NavItem>
+                    <NavItem eventKey="edit" href={this.props.edit_path}>Edit Course</NavItem>
+                </Nav>
             </Fragment>
         );
     }
 }
 
 CourseNavBar.propTypes = {
-    currentPath: PropTypes.string.isRequired
+    current_path: PropTypes.string.isRequired,
+    roster_path: PropTypes.string.isRequired,
+    project_teams_path: PropTypes.string.isRequired,
+    org_teams_path: PropTypes.string.isRequired,
+    repos_path: PropTypes.string.isRequired,
+    slack_path: PropTypes.string.isRequired,
+    jobs_path: PropTypes.string.isRequired,
+    edit_path: PropTypes.string.isRequired
 };
 
 export default CourseNavBar;

--- a/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
+++ b/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
@@ -9,7 +9,7 @@ class CourseNavBar extends Component {
         const pathMatchRegex = new RegExp('\/courses\/[0-9]*/([^/]*)', 'i');
         const coursePathMatches = pathMatchRegex.exec(this.props.current_path);
         if (coursePathMatches == null || coursePathMatches.length <= 1) {
-            return 'roster';
+            return 'roster_students';
         }
         return coursePathMatches[1];
     }
@@ -19,7 +19,7 @@ class CourseNavBar extends Component {
         return (
             <Fragment>
                 <Nav bsStyle="tabs" activeKey={activeTabKey}>
-                    <NavItem eventKey="roster" href={this.props.roster_path}>Students</NavItem>
+                    <NavItem eventKey="roster_students" href={this.props.roster_path}>Students</NavItem>
                     <NavDropdown title="Teams">
                         <MenuItem eventKey="project_teams" href={this.props.project_teams_path}>Project Teams</MenuItem>
                         <MenuItem eventKey="org_teams" href={this.props.org_teams_path}>GitHub Teams</MenuItem>
@@ -27,7 +27,7 @@ class CourseNavBar extends Component {
                     <NavItem eventKey="repos" href={this.props.repos_path}>Repositories</NavItem>
                     <NavItem eventKey="slack" href={this.props.slack_path}>Slack</NavItem>
                     <NavItem eventKey="jobs" href={this.props.jobs_path}>Jobs</NavItem>
-                    <NavItem eventKey="edit" href={this.props.edit_path}>Edit Course</NavItem>
+                    <NavItem eventKey="edit" href={this.props.edit_path} disabled={!this.props.can_edit}>Edit Course</NavItem>
                 </Nav>
             </Fragment>
         );
@@ -42,7 +42,8 @@ CourseNavBar.propTypes = {
     repos_path: PropTypes.string.isRequired,
     slack_path: PropTypes.string.isRequired,
     jobs_path: PropTypes.string.isRequired,
-    edit_path: PropTypes.string.isRequired
+    edit_path: PropTypes.string.isRequired,
+    can_edit: PropTypes.bool.isRequired
 };
 
 export default CourseNavBar;

--- a/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
+++ b/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
@@ -3,11 +3,11 @@ import * as PropTypes from 'prop-types';
 import {Row, Col, MenuItem, Tab, Nav, NavItem, NavDropdown, Button} from "react-bootstrap";
 
 class CourseNavBar extends Component {
-    currentActiveTab = () => {
+    currentActiveTab = (currentPath) => {
         // Captures path after the course index.
         // E.g. for path '/courses/1/project_teams/new', this captures 'project_teams'.
         const pathMatchRegex = new RegExp('\/courses\/[0-9]*/([^/]*)', 'i');
-        const coursePathMatches = pathMatchRegex.exec(this.props.current_path);
+        const coursePathMatches = pathMatchRegex.exec(currentPath);
         if (coursePathMatches == null || coursePathMatches.length <= 1) {
             return 'roster_students';
         }
@@ -15,7 +15,7 @@ class CourseNavBar extends Component {
     }
 
     render() {
-        const activeTabKey = this.currentActiveTab();
+        const activeTabKey = this.currentActiveTab(this.props.current_path);
         return (
             <Fragment>
                 <Nav bsStyle="tabs" activeKey={activeTabKey}>

--- a/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
+++ b/app/javascript/bundles/CourseNavBar/components/CourseNavBar.jsx
@@ -1,0 +1,18 @@
+import React, {Component, Fragment} from 'react';
+import * as PropTypes from 'prop-types';
+
+class CourseNavBar extends Component {
+    render() {
+        return (
+            <Fragment>
+
+            </Fragment>
+        );
+    }
+}
+
+CourseNavBar.propTypes = {
+    currentPath: PropTypes.string.isRequired
+};
+
+export default CourseNavBar;

--- a/app/javascript/bundles/ProjectTeams/components/Dashboard/TeamsDashboard.jsx
+++ b/app/javascript/bundles/ProjectTeams/components/Dashboard/TeamsDashboard.jsx
@@ -30,7 +30,6 @@ class TeamsDashboard extends Component {
         return (
             <Fragment>
                 <Button style={{float: 'right'}} bsStyle="primary" onClick={() => this.onNewTeamClick()}>Add Team</Button>
-                <Button style={{float: 'right', marginRight: 10}} bsStyle="default" href='org_teams'>All Teams</Button>
                 <br/>
                 <TeamsTable teams={this.state.teams} {...this.props}/>
             </Fragment>

--- a/app/javascript/bundles/ProjectTeams/components/Dashboard/TeamsDashboard.jsx
+++ b/app/javascript/bundles/ProjectTeams/components/Dashboard/TeamsDashboard.jsx
@@ -30,6 +30,7 @@ class TeamsDashboard extends Component {
         return (
             <Fragment>
                 <Button style={{float: 'right'}} bsStyle="primary" onClick={() => this.onNewTeamClick()}>Add Team</Button>
+                <Button style={{float: 'right', marginRight: 10}} bsStyle="default" href='org_teams'>All Teams</Button>
                 <br/>
                 <TeamsTable teams={this.state.teams} {...this.props}/>
             </Fragment>

--- a/app/javascript/bundles/Users/components/Users.jsx
+++ b/app/javascript/bundles/Users/components/Users.jsx
@@ -99,7 +99,6 @@ class Users extends Component {
                     onSearchChanged={this.onSearchChanged}
                     onTypeChanged={this.onTypeChanged}
                 />
-                <br />
                 <UsersTable
                     users={this.state.users}
                     page={this.state.page}

--- a/app/javascript/bundles/Users/components/UsersSearch.jsx
+++ b/app/javascript/bundles/Users/components/UsersSearch.jsx
@@ -5,7 +5,7 @@ import {Form, FormControl, FormGroup, ControlLabel} from "react-bootstrap";
 class UsersSearch extends Component {
     render() {
         return (
-            <Form horizontal>
+            <Form>
                 <FormGroup>
                     <ControlLabel>User Type</ControlLabel>
                     <FormControl

--- a/app/javascript/packs/react-bundle.js
+++ b/app/javascript/packs/react-bundle.js
@@ -2,8 +2,10 @@ import ReactOnRails from 'react-on-rails';
 
 import Users from '../bundles/Users/components/Users';
 import ProjectTeams from "../bundles/ProjectTeams/components/ProjectTeams";
+import CourseNavBar from "../bundles/CourseNavBar/components/CourseNavBar";
 
 ReactOnRails.register({
   Users,
-  ProjectTeams
+  ProjectTeams,
+  CourseNavBar
 });

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -34,35 +34,14 @@
 
       <% end %>
 
-      <%= link_to "View Jobs", course_jobs_path(@course), method: :get, class: "btn btn-default",
-                  style: "display:inline-block; float: right; margin-left: 10px;" %>
-
-      <div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Manage Students <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <% if can? :create, RosterStudent %>
-            <li> <%= link_to 'New Student', new_course_roster_student_path(@course) %> </li>
-          <% end %>
-          <li role="separator" class="divider"></li>
-          <li> <%= link_to "Download CSV Roster", course_roster_students_path(@course, :format => "csv"), method: :get %> </li>
-        </ul>
-      </div>
-
-      <%= link_to "Teams", course_project_teams_path(@course), method: :get, class: "btn btn-default",
-                  style: "display:inline-block; float: right; margin-left: 10px;" %>
-
-      <%= link_to "Repositories", course_repos_path(@course), method: :get, class: "btn btn-default",
-                  style: "display:inline-block; float: right; margin-left: 10px;" %>
-
-      <%= link_to "Slack", course_slack_path(@course), method: :get, class: "btn btn-default",
-                  style: "display:inline-block; float: right; margin-left: 10px;" %>
-
-
-      <% if can? :update, @course %>
-        <%= link_to 'Edit', edit_course_path(@course), class: 'btn' %>
+      <% if can? :create, RosterStudent %>
+        <%= link_to "New Student", course_roster_student_path(@course), method: :get, class: "btn btn-default",
+                    style: "display:inline-block; float: right; margin-left: 10px;" %>
       <% end %>
+
+      <%= link_to "Download CSV Roster", course_roster_students_path(@course, :format => "csv"), method: :get, class:
+          "btn btn-default",
+                  style: "display:inline-block; float: right; margin-left: 10px;" %>
 
     </div>
 
@@ -98,7 +77,6 @@
         <th data-sortable="true" data-field="OrgMembership" data-filter-control="select">Org Status</th>
         <th data-sortable="true" data-field="Teams" data-filter-control="input">Teams</th>
         <th></th>
-        <th></th>
       </tr>
       </thead>
 
@@ -106,7 +84,7 @@
       <% @course.roster_students.each do |student| %>
         <tr>
           <td><%= student.perm %></td>
-          <td><%= student.full_name %></td>
+          <td><%= link_to student.full_name, course_roster_student_path(@course, student) %></td>
           <td><%= student.email %></td>
           <td><%= student.enrolled ? "True" : "False" %></td>
           <td><%= student.section %></td>
@@ -133,7 +111,6 @@
               <%= link_to(team.name, team.url) + (", " unless index == student.org_teams.size - 1) %>
             <% end %>
           </td>
-          <td><%= link_to 'Show', course_roster_student_path(@course, student) %></td>
           <% if can? :destroy, student %>
             <td><%= link_to 'Remove', course_roster_student_path(@course, student), method: :delete, data: {confirm: 'Are you sure?'} %></td>
           <% end %>

--- a/app/views/courses/_show_admin.html.erb
+++ b/app/views/courses/_show_admin.html.erb
@@ -50,21 +50,15 @@
         </ul>
       </div>
 
-      <div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          GitHub <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li> <%= link_to "Teams", course_org_teams_path(@course), method: :get %></li>
-          <li> <%= link_to "Repositories", course_repos_path(@course), method: :get %> </li>
-        </ul>
-      </div>
+      <%= link_to "Teams", course_project_teams_path(@course), method: :get, class: "btn btn-default",
+                  style: "display:inline-block; float: right; margin-left: 10px;" %>
+
+      <%= link_to "Repositories", course_repos_path(@course), method: :get, class: "btn btn-default",
+                  style: "display:inline-block; float: right; margin-left: 10px;" %>
 
       <%= link_to "Slack", course_slack_path(@course), method: :get, class: "btn btn-default",
                   style: "display:inline-block; float: right; margin-left: 10px;" %>
 
-      <%= link_to "Project Teams", course_project_teams_path(@course), method: :get, class: "btn btn-default",
-                  style: "display:inline-block; float: right; margin-left: 10px;" %>
 
       <% if can? :update, @course %>
         <%= link_to 'Edit', edit_course_path(@course), class: 'btn' %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -1,5 +1,3 @@
-<h1>Editing Course</h1>
-
 <%= render 'form', course: @course %>
 
 <%= link_to 'Show', @course %> |

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -1,5 +1,3 @@
-<h1> <%= link_to @course.name, course_path(@course) %> </h1>
-
 <div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">Jobs</h3>

--- a/app/views/courses/org_teams/index.html.erb
+++ b/app/views/courses/org_teams/index.html.erb
@@ -1,15 +1,9 @@
-<h1> <%= link_to @course.name, course_path(@course) %>
-  <div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
-    <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Manage Teams <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu">
-      <li> <%= link_to 'Create Teams from CSV', create_teams_course_org_teams_path%></li>
-      <li> <%= link_to 'Create Team Repositories', create_repos_course_org_teams_path%> </li>
-    </ul>
-  </div>
-</h1>
-<p></p>
+<h1> <%= link_to @course.name, course_path(@course) %> </h1>
+<div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
+  <%= link_to "Project Teams", course_project_teams_path(@course), method: :get, class: "btn btn-default",
+              style: "display:inline-block; float: right; margin-left: 10px;" %>
+</div>
+<br /> <br />
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   <% collapsed = "in" # slightly messy way to make only the first panel expanded on page load while allowing more than one to be expanded at a time %>
   <% @teams.each do |team| %>
@@ -46,7 +40,7 @@
                     <td>
                       <div id="<%= student.roster_student.full_name %>" class="hidden-sort-div"></div>
                       <%= link_to student.roster_student.full_name, course_roster_student_path(@course, student.roster_student) %>
-                      </td>
+                    </td>
                     <td><%= link_to student.roster_student.user.username, "https://github.com/#{student.roster_student.user.username}" %></td>
                     <td>
                       <div id="<%= student.role %>" class="hidden-sort-div"></div>

--- a/app/views/courses/org_teams/index.html.erb
+++ b/app/views/courses/org_teams/index.html.erb
@@ -1,4 +1,3 @@
-<h1> <%= link_to @course.name, course_path(@course) %> </h1>
 <div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
   <%= link_to "Project Teams", course_project_teams_path(@course), method: :get, class: "btn btn-default",
               style: "display:inline-block; float: right; margin-left: 10px;" %>

--- a/app/views/courses/org_teams/index.html.erb
+++ b/app/views/courses/org_teams/index.html.erb
@@ -1,8 +1,3 @@
-<div class="btn-group" style="display: inline-block; float: right; margin-left: 10px;">
-  <%= link_to "Project Teams", course_project_teams_path(@course), method: :get, class: "btn btn-default",
-              style: "display:inline-block; float: right; margin-left: 10px;" %>
-</div>
-<br /> <br />
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   <% collapsed = "in" # slightly messy way to make only the first panel expanded on page load while allowing more than one to be expanded at a time %>
   <% @teams.each do |team| %>

--- a/app/views/courses/project_teams/index.html.erb
+++ b/app/views/courses/project_teams/index.html.erb
@@ -1,2 +1,1 @@
-<h1><%= link_to @course.name, course_path(@course) %></h1>
 <%= react_component("ProjectTeams", prerender: false) %>

--- a/app/views/courses/repos.html.erb
+++ b/app/views/courses/repos.html.erb
@@ -1,5 +1,3 @@
-<h1>Course Repositories</h1>
-
 <%= form_tag course_search_repos_path, method: :get do %>
   <div class="input-group">
     <span class="input-group-addon" id="basic-addon1">(.*)</span>

--- a/app/views/courses/roster_students/show.html.erb
+++ b/app/views/courses/roster_students/show.html.erb
@@ -1,4 +1,7 @@
-<h2><%= @roster_student.full_name %></h2>
+<!--<h2><%#= @roster_student.full_name %></h2>-->
+<%= link_to '< Back', course_path(@parent), :class => "btn btn-outline-secondary", :style => "padding-left:0;" %> |
+<%= link_to 'Edit', edit_course_roster_student_path(@parent, @roster_student), :class => "btn btn-outline-secondary
+text-left" %>
 <dl class="dl-horizontal">
   <dt>Student ID</dt>
   <dd> <%= @roster_student.perm %></dd>
@@ -50,8 +53,8 @@
   <% end %>
 
   <% unless @roster_student.org_teams.empty? %>
-  <p>
-    <strong>Teams</strong>
+    <p>
+      <strong>Teams</strong>
     <table class="table">
       <thead>
       <tr>
@@ -66,43 +69,40 @@
         </tr>
       <% end %>
     </table>
-  </p>
+    </p>
   <% end %>
 
   <p class="repo-list-table">
     <% org_repos = find_org_repos %>
     <% unless org_repos.empty? %>
-    <strong>Repositories</strong>
-    <table class="table">
-      <thead>
-      <tr>
-        <th>Repository (Student Name)</th>
-        <th>GitHub ID</th>
-        <th>Visibility (Permission Level)</th>
-      </tr>
-      </thead>
-      <% org_repos.each do |repo| %>
+      <strong>Repositories</strong>
+      <table class="table">
+        <thead>
         <tr>
-          <td><a href=<%= repo.url %>><%= repo.name %></td>
-          <td></td>
-          <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
+          <th>Repository (Student Name)</th>
+          <th>GitHub ID</th>
+          <th>Visibility (Permission Level)</th>
         </tr>
-        <% repo.find_contributors.each do |contributor| %>
-          <tr class="leftMargin">
-            <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
-                            course_roster_student_path(@parent, contributor["id"]) %></td>
-            <td><a href="https://github.com/<%= contributor["username"] %>"><%= contributor["username"] %></td>
-            <td><a href="<%= repo.url %>/settings/access"><%= contributor["permission_level"] %></td>
+        </thead>
+        <% org_repos.each do |repo| %>
+          <tr>
+            <td><a href=<%= repo.url %>><%= repo.name %></td>
+            <td></td>
+            <td><a href=<%= repo.url + "/settings" %>><%= repo.visibility %></td>
           </tr>
+          <% repo.find_contributors.each do |contributor| %>
+            <tr class="leftMargin">
+              <td><%= link_to "#{contributor["first_name"]} #{contributor["last_name"]}",
+                              course_roster_student_path(@parent, contributor["id"]) %></td>
+              <td><a href="https://github.com/<%= contributor["username"] %>"><%= contributor["username"] %></td>
+              <td><a href="<%= repo.url %>/settings/access"><%= contributor["permission_level"] %></td>
+            </tr>
+          <% end %>
         <% end %>
-      <% end %>
-    </table>
+      </table>
     <% end %>
-  </p>
+    </p>
 
 <% else %>
-  <p class="no-repo-list-table"> </p>
+  <p class="no-repo-list-table"></p>
 <% end %>
-
-<%= link_to 'Edit', edit_course_roster_student_path(@parent, @roster_student), :class => "btn btn-outline-secondary" %> |  
-<%= link_to 'Back', course_path(@parent), :class => "btn btn-outline-secondary" %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,7 +1,3 @@
-<h1> <%= @course.name %> </h1>
-
-<hr>
-
 <% if current_user.can? :read, @course %>
   <%= render 'show_admin', course: Course.new %>
 <% elsif current_user.can? :show, @course %>

--- a/app/views/courses/slack/show.html.erb
+++ b/app/views/courses/slack/show.html.erb
@@ -1,9 +1,8 @@
-<h1><%= link_to @parent.name, course_path(@parent)%></h1>
-
 <% bot_scope = "calls:read,calls:write,channels:read,chat:write,commands,groups:read,groups:write,im:history,im:read,im:write,incoming-webhook,mpim:history,mpim:read,mpim:write,pins:write,reactions:read,reactions:write,team:read,usergroups:read,usergroups:write,users.profile:read,users:read,users:read.email,users:write" %>
 <% user_scope = "identity.basic" %>
 <% redirect_uri = callback_slack_auth_url %>
-<% slack_oauth_link = "https://slack.com/oauth/v2/authorize?client_id=#{ENV['SLACK_CLIENT_ID']}&scope=#{bot_scope}&user_scope=#{user_scope}&state=#{@parent.id}&redirect_uri=#{redirect_uri}"%>
+<% slack_oauth_link = "https://slack.com/oauth/v2/authorize?client_id=#{ENV['SLACK_CLIENT_ID']}&scope=#{bot_scope
+}&user_scope=#{user_scope}&state=#{@course.id}&redirect_uri=#{redirect_uri}"%>
 
 <% if @workspace.nil? %>
   <a href="<%= slack_oauth_link %>">
@@ -22,7 +21,8 @@
 
   <div class="btn-group" role="group">
   <%= link_to "Change Workspace", slack_oauth_link, class: "btn btn-secondary" %>
-  <%= link_to "Remove Workspace", course_slack_path(@parent), method: :delete, data: { confirm: "Are you sure you want to remove this workspace?" }, class: "btn btn-secondary" %>
+  <%= link_to "Remove Workspace", course_slack_path(@course), method: :delete, data: { confirm: "Are you sure you want
+   to remove this workspace?" }, class: "btn btn-secondary" %>
   </div>
 
 <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,4 @@
+<% content_for :main_content do %>
+  <%= yield %>
+<% end %>
+<%= render template: "layouts/application" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <%= render 'layouts/messages' %>
       <div class="container"> 
         <%# begin the container where the body content goes %>
-        <%= yield %>
+        <%= yield :main_content %>
       </div>
     </main>
   </body>

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -1,6 +1,14 @@
 <% content_for :main_content do %>
   <% if @course.present? %>
     <h1> <%= link_to @course.name, course_path(@course) %> </h1>
+    <%= react_component("CourseNavBar",
+                        props: {current_path: request.env['PATH_INFO'], roster_path: course_path(@course),
+                                project_teams_path: course_project_teams_path(@course), org_teams_path: course_org_teams_path(@course),
+                                repos_path: course_repos_path(@course), slack_path: course_slack_path(@course),
+                                jobs_path: course_jobs_path(@course), edit_path: edit_course_path(@course)
+                        },
+                        prerender: true) %>
+    <br/>
   <% end %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -1,6 +1,7 @@
 <% content_for :main_content do %>
-  <h1> <%= link_to @course.name, course_path(@course) %> </h1>
-  <hr>
+  <% if @course.present? %>
+    <h1> <%= link_to @course.name, course_path(@course) %> </h1>
+  <% end %>
   <%= yield %>
 <% end %>
 <%= render template: "layouts/application" %>

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -5,7 +5,8 @@
                         props: {current_path: request.env['PATH_INFO'], roster_path: course_path(@course),
                                 project_teams_path: course_project_teams_path(@course), org_teams_path: course_org_teams_path(@course),
                                 repos_path: course_repos_path(@course), slack_path: course_slack_path(@course),
-                                jobs_path: course_jobs_path(@course), edit_path: edit_course_path(@course)
+                                jobs_path: course_jobs_path(@course), edit_path: edit_course_path(@course),
+                                can_edit: can?(:update, @course)
                         },
                         prerender: true) %>
     <br/>

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_content do %>
-  <% if @course.present? %>
+  <% if @course.present? && @course.id.present? %>
     <h1> <%= link_to @course.name, course_path(@course) %> </h1>
     <%= react_component("CourseNavBar",
                         props: {current_path: request.env['PATH_INFO'], roster_path: course_path(@course),

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -1,0 +1,6 @@
+<% content_for :main_content do %>
+  <h1> <%= link_to @course.name, course_path(@course) %> </h1>
+  <hr>
+  <%= yield %>
+<% end %>
+<%= render template: "layouts/application" %>

--- a/app/views/layouts/users.html.erb
+++ b/app/views/layouts/users.html.erb
@@ -1,0 +1,4 @@
+<% content_for :main_content do %>
+  <%= yield %>
+<% end %>
+<%= render template: "layouts/application" %>

--- a/app/views/layouts/visitors.html.erb
+++ b/app/views/layouts/visitors.html.erb
@@ -1,0 +1,4 @@
+<% content_for :main_content do %>
+  <%= yield %>
+<% end %>
+<%= render template: "layouts/application" %>


### PR DESCRIPTION
This PR implements a reorganization of the course UX as well as several other minor UI changes. Specifically:

- A new React navigation bar is implemented for a course which can be used to navigate between different menus like the Repos page, Project Teams page etc. quickly. It looks like this: 
<img width="1502" alt="Screen Shot 2020-05-27 at 9 52 20 AM" src="https://user-images.githubusercontent.com/34611522/83049274-c3486580-9fff-11ea-9d68-112ddbe52406.png">
- A minor fix is made to the search field on the Users page to make the labels aligned.
- Many layout files are added to avoid UI code replication.
