### PR TITLE
pc - allow CSV upload of GitHub ids

### DIFF
--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -21,9 +21,16 @@ $(document).ready(function () {
                 " font-weight:" +
                 " bold;'>";
 
-            var fields = [{value: 'select', name: '-- select --'}, {value: 'full_name', name: 'Full Name'},
-                {value: 'first_name', name: 'First Name'}, {value: 'last_name', name: 'Last Name'},
-                {value: 'student_id', name: 'Student ID'}, {value: 'email', name: 'Email'}, {value: 'section', name: 'Section'}];
+            var fields = [
+                {value: 'select', name: '-- select --'}, 
+                {value: 'full_name', name: 'Full Name'},
+                {value: 'first_name', name: 'First Name'}, 
+                {value: 'last_name', name: 'Last Name'},
+                {value: 'student_id', name: 'Student ID'}, 
+                {value: 'email', name: 'Email'}, 
+                {value: 'section', name: 'Section'},
+                {value: 'github_username', name: 'Github Username'},
+            ];
 
             for (var i = 0; i < fields.length; i++) {
                 dropdownHtml += "<option value='" + fields[i].value + "' >" + fields[i].name + "</option>";

--- a/app/jobs/course/update_github_repos_job.rb
+++ b/app/jobs/course/update_github_repos_job.rb
@@ -69,6 +69,10 @@ class UpdateGithubReposJob < CourseJob
   # We have to manually handle pagination because Octokit has no built-in support for GraphQL
   def get_github_repos(course_org, cursor = "")
     response = github_machine_user.post '/graphql', { query: repository_graphql_query(course_org, cursor) }.to_json
+    if !response.respond_to?(:data) || response.respond_to?(:errors)
+      puts "ERROR: response is: #{response.to_json}"
+      return []
+    end   
     repo_list = repo_list_from_response(response)
     if repo_list.count < 100 # If there are less than 100 records (max page size), this is the last page
       return repo_list


### PR DESCRIPTION
In this commit, we add code that allows CSV files to have a GitHub id column.

If filled in, and if the GitHub id is valid, it will add the github id to the Roster Student
record.  This allows CSV download/upload to use used to migrate a course from one
instance of the app to another.

If the user has never logged in, the user record is created in the user table.