### PR TITLE
pc - fix typo in instructions for creating teams from CSV

### DIFF
--- a/app/views/courses/org_teams/create_teams.html.erb
+++ b/app/views/courses/org_teams/create_teams.html.erb
@@ -1,5 +1,5 @@
 <p>On this page, you can upload a CSV to automatically generate GitHub teams with members in them. The CSV should include
-two columns: GitHub ID first, and the team to assign that GitHub user two in the second column. For example:</p>
+two columns: GitHub ID first, and the team to assign that GitHub user to in the second column. For example:</p>
 
 <samp>
   bob13,Instructors<br>


### PR DESCRIPTION
This PR fixes a typo in the instructions on the create teams from CSV page