### PR TITLE
On course page, change repositories to repo drop down

### DIFF
--- a/app/javascript/components/CourseNavBar/CourseNavBar.jsx
+++ b/app/javascript/components/CourseNavBar/CourseNavBar.jsx
@@ -30,7 +30,9 @@ class CourseNavBar extends Component {
                         <MenuItem eventKey="create_teams" href={this.props.create_teams_path}>Create Teams From CSV</MenuItem>
                         <MenuItem eventKey="create_repos" href={this.props.create_team_repos_path}>Create Team Repos</MenuItem>
                     </NavDropdown>
-                    <NavItem eventKey="repos" href={this.props.repos_path}>Repositories</NavItem>
+                    <NavDropdown title="Repos">
+                        <MenuItem eventKey="repos" href={this.props.repos_path}>Repo Search</MenuItem>
+                    </NavDropdown>
                     <NavItem eventKey="events" href={this.props.events_path}>Events</NavItem>
                     <NavItem eventKey="slack" href={this.props.slack_path}>Slack</NavItem>
                     <NavItem eventKey="jobs" href={this.props.jobs_path}>Jobs</NavItem>


### PR DESCRIPTION
This PR makes a small UI change on the course page.

Instead of a tab "Repositories" that links directly to the repo search page, there is a drop down titled "Repo"
that has "Repo Search" as (currently) the one and only option.  "Repo Search" goes where "Repositories" used to go,
to the repo search page.

This makes room to add additional functions to the repo
drop down menu, including commit download functions that are
planned for the future.