### PR TITLE
pc - fix bug #268 (admin level jobs crash wrong num params)

### DIFF
--- a/app/jobs/admin/purge_completed_jobs_job.rb
+++ b/app/jobs/admin/purge_completed_jobs_job.rb
@@ -5,7 +5,7 @@ class PurgeCompletedJobsJob < AdminJob
   @confirmation_dialog = "Are you sure you want to delete all records of completed jobs?"
   @job_description = "Deletes all completed job records from the database."
 
-  def attempt_job
+  def attempt_job(_options)
     jobs_deleted = CompletedJob.destroy_all
     "#{pluralize jobs_deleted.size, "job"} deleted."
   end

--- a/app/jobs/admin/purge_unused_users_job.rb
+++ b/app/jobs/admin/purge_unused_users_job.rb
@@ -5,7 +5,7 @@ class PurgeUnusedUsersJob < AdminJob
   @confirmation_dialog = "Are you sure you want to delete all non-admin/instructor users not enrolled in a course?"
   @job_description = "Removes all users who are not instructors/admins that are not enrolled in any existing course."
 
-  def attempt_job
+  def attempt_job(_options)
     num_removed = 0
     users = User.all
     users.each do |user|


### PR DESCRIPTION
In this PR we fix bug #268 where admin jobs can no longer run.

* STR: Try to run any admin level job
* Observed: Job crashes with "incorrect number of parameters"
* Desired: Jon runs successfully

Root cause: code for course level jobs was refactored, but code for admin level jobs was not refactored to match.

Solution: Add `(_options)` parameter (ignored) to `attempt_job` method of admin level jobs. (`_options` syntax signals to style checkers that the coder knows it is an unused variable, and that that fact should be ignored.)