### PR TITLE
Pc refactor jobs to use react

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -33,6 +33,19 @@ class AdminController < ApplicationController
     end
     helper_method :admin_job_list
 
+    # List of jobs to make available to run
+    def admin_job_info_list
+      jobs = admin_job_list
+      jobs_info = jobs.map { |j|
+        j.instance_values.merge({
+            "last_run" => j.itself.last_run,
+            "job_description" => j.itself.job_description
+         })
+      }
+      jobs_info
+    end
+    helper_method :admin_job_info_list
+
     def run_admin_job
       job_name = params[:job_name]
       job = admin_job_list.find { |job| job.job_short_name == job_name }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -144,6 +144,20 @@ class CoursesController < ApplicationController
   end
   helper_method :course_job_list
 
+  # List of course jobs to make available to run
+  def course_job_info_list
+    jobs = course_job_list
+    jobs_info = jobs.map{ |j| 
+      j.instance_values.merge({ 
+        "last_run" => j.itself.last_run,
+        "job_description" => j.itself.job_description
+        }
+      )  
+    }
+    jobs_info
+  end
+  helper_method :course_job_info_list
+
   def repos
     @course = Course.find(params[:course_id])
     @repos = GithubRepo.where(course_id: params[:course_id]).where("name ~* ?", params[:search]).order(:name)

--- a/app/javascript/components/Jobs/JobLauncher.jsx
+++ b/app/javascript/components/Jobs/JobLauncher.jsx
@@ -1,0 +1,53 @@
+
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+import axios from "../../helpers/axios-rails";
+import ReactOnRails from "react-on-rails";
+import JobLauncherItem from "./JobLauncherItem";
+
+class JobLauncher extends Component {
+    constructor(props) {
+        super(props);
+        const csrfToken = ReactOnRails.authenticityToken();
+        axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+        axios.defaults.params = {}
+        axios.defaults.params['authenticity_token'] = csrfToken;
+    }
+
+    render() {
+        return (
+            <Fragment>
+                <div className="panel panel-default">
+                    <div className="panel-heading">
+                        <div className="panel-title">Jobs</div>
+                    </div>
+                    <div className="panel-body">
+
+                        <table className="table">
+                            <thead>
+                                <tr>
+                                    <th>Job Name</th>
+                                    <th>Last Run</th>
+                                    <th colSpan="1"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {this.props.jobs_list.map(job =>
+                                    <JobLauncherItem key={`job-${job.job_short_name}`} job={job} {...this.props} />
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </Fragment>
+        );
+    }
+}
+
+JobLauncher.propTypes = {
+    jobs_list: PropTypes.array.isRequired
+};
+
+export default JobLauncher;
+
+

--- a/app/javascript/components/Jobs/JobLauncherItem.jsx
+++ b/app/javascript/components/Jobs/JobLauncherItem.jsx
@@ -1,0 +1,36 @@
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+
+class JobLauncherItem extends Component {
+    render() {
+        const j = this.props.job; // Save some characters
+
+        var confirmationDialogProps = {}
+        if (j.confirmation_dialog) {
+            confirmationDialogProps = {
+                "data-confirm": j.confirmation_dialog
+            };
+        }
+        return (
+            <tr>
+                <td><span className="job_name" data-toggle="tooltip" title={`${j.job_description}`} >{j.job_name}</span></td>
+                <td>{j.last_run}</td>
+                <td>
+                    <a
+                        {...confirmationDialogProps}
+                        rel="nofollow"
+                        data-method="post"
+                        href={`${this.props.run_url_prefix}?job_name=${j.job_short_name}`}>
+                        Run Job
+                    </a>
+                </td>
+            </tr >
+        );  
+    }
+}
+
+JobLauncherItem.propTypes = {
+    job: PropTypes.object.isRequired
+};
+
+export default JobLauncherItem;

--- a/app/javascript/components/Jobs/JobLog.jsx
+++ b/app/javascript/components/Jobs/JobLog.jsx
@@ -1,0 +1,54 @@
+
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+import axios from "../../helpers/axios-rails";
+import ReactOnRails from "react-on-rails";
+import JobLogItem from "./JobLogItem";
+
+class JobLog extends Component {
+    constructor(props) {
+        super(props);
+        const csrfToken = ReactOnRails.authenticityToken();
+        axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+        axios.defaults.params = {}
+        axios.defaults.params['authenticity_token'] = csrfToken;
+    }
+
+    render() {
+        return (
+            <Fragment>
+                <div className="panel panel-default">
+                    <div className="panel-heading">
+                        <div className="panel-title">Job Log</div>
+                    </div>
+                    <div className="panel-body">
+
+                        <table data-toggle="table" className="table">
+                            <thead>
+                                <tr>
+                                    <th data-sortable="true">Job Name</th>
+                                    <th data-sortable="true">Date Run</th>
+                                    <th>Time Elapsed</th>
+                                    <th>Summary</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {this.props.completed_jobs_list.map(completed_job =>
+                                    <JobLogItem key={`completed-job-${completed_job.id}`} completed_job={completed_job} {...this.props} />
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </Fragment>
+        );
+    }
+}
+
+JobLog.propTypes = {
+    completed_jobs_list: PropTypes.array.isRequired
+};
+
+export default JobLog;
+
+

--- a/app/javascript/components/Jobs/JobLogItem.jsx
+++ b/app/javascript/components/Jobs/JobLogItem.jsx
@@ -1,0 +1,22 @@
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+
+class JobLogItem extends Component {
+    render() {
+        const cj = this.props.completed_job; // Save some characters
+        return(
+                <tr key={`completed-job-${cj.id}`}> 
+                    <td>{cj.job_name}</td>
+                    <td>{cj.run_at}</td>
+                    <td>{cj.time_elapsed}</td>
+                    <td>{cj.summary}</td>
+                </tr>
+            );
+    }
+}
+
+JobLogItem.propTypes = {
+    completed_job: PropTypes.object.isRequired
+};
+
+export default JobLogItem;

--- a/app/javascript/packs/react-bundle.js
+++ b/app/javascript/packs/react-bundle.js
@@ -4,11 +4,17 @@ import Users from '../components/Users/Users';
 import ProjectTeams from "../components/ProjectTeams/ProjectTeams";
 import CourseNavBar from "../components/CourseNavBar/CourseNavBar";
 import StudentActivity from "../components/ActivityDashboard/Student/StudentActivity";
+import JobLauncher from "../components/Jobs/JobLauncher";
+import JobLog from "../components/Jobs/JobLog";
+
+
 import "../styles.css"
 
 ReactOnRails.register({
   Users,
   ProjectTeams,
   CourseNavBar,
-  StudentActivity
+  StudentActivity,
+  JobLauncher,
+  JobLog
 });

--- a/app/jobs/admin/purge_completed_jobs_job.rb
+++ b/app/jobs/admin/purge_completed_jobs_job.rb
@@ -5,7 +5,7 @@ class PurgeCompletedJobsJob < AdminJob
   @confirmation_dialog = "Are you sure you want to delete all records of completed jobs?"
   @job_description = "Deletes all completed job records from the database."
 
-  def attempt_job
+  def attempt_job(_options)
     jobs_deleted = CompletedJob.destroy_all
     "#{pluralize jobs_deleted.size, "job"} deleted."
   end

--- a/app/jobs/admin/purge_unused_users_job.rb
+++ b/app/jobs/admin/purge_unused_users_job.rb
@@ -5,7 +5,7 @@ class PurgeUnusedUsersJob < AdminJob
   @confirmation_dialog = "Are you sure you want to delete all non-admin/instructor users not enrolled in a course?"
   @job_description = "Removes all users who are not instructors/admins that are not enrolled in any existing course."
 
-  def attempt_job
+  def attempt_job(_options)
     num_removed = 0
     users = User.all
     users.each do |user|

--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -26,10 +26,11 @@ class BackgroundJob
   end
 
   def self.last_run
-    if CompletedJob.where(job_short_name: @job_short_name).last.nil?
+    the_last_run = CompletedJob.where(job_short_name: @job_short_name).last
+    if the_last_run.nil?
       return "N/A"
     end
-    CompletedJob.where(job_short_name: @job_short_name).last.created_at
+    the_last_run.created_at.to_formatted_s(:rfc822)
   end
 
   def self.permission_level

--- a/app/jobs/course/test_job.rb
+++ b/app/jobs/course/test_job.rb
@@ -3,8 +3,16 @@ class TestJob < CourseJob
   @job_name = "Test Job"
   @job_short_name = "test_job"
   @job_description = "Adds a completed job record for this course for testing purposes."
+  
 
   def attempt_job(options)
     "Test completed."
   end
+
+  @confirmation_dialog = "Are you sure you want to run this test job?"
+
+  def self.confirmation_dialog
+    @confirmation_dialog
+  end
+
 end

--- a/app/models/completed_job.rb
+++ b/app/models/completed_job.rb
@@ -13,7 +13,14 @@ class CompletedJob < ApplicationRecord
   end
 
   def self.last_ten_jobs(course_id)
-    CompletedJob.where(course_id: course_id).reverse_order.limit(10)
+    records = CompletedJob.where(course_id: course_id).reverse_order.limit(10)
+    completed_jobs_info = records.map { |cj|
+      cj.attributes.merge({
+        "run_at" => cj.created_at.to_formatted_s(:rfc822),
+        "time_elapsed" => cj.time_elapsed,
+      })
+    }  
+    completed_jobs_info
   end
 
 end

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -32,65 +32,14 @@
   </div>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <div class="panel-title">Jobs</div>
-  </div>
-  <div class="panel-body">
+<%= react_component("JobLauncher", prerender: false, props: {
+    jobs_list: admin_job_info_list,
+    run_url_prefix: "/admin/run_admin_job"
+}) %>
 
-    <table class="table">
-      <thead>
-      <tr>
-        <th>Job Name</th>
-        <th>Last Run</th>
-        <th colspan="1"></th>
-      </tr>
-      </thead>
-      <tbody>
-      <% admin_job_list.each do |job| %>
-        <tr>
-          <td><span class="job_name" data-toggle="tooltip" title = "<%= job.job_description %>"><%= job.job_name %></span></td>
-          <td><%= job.last_run %></td>
-          <td><%= link_to 'Run Job', run_admin_job_admin_path(job_name: job.job_short_name),
-                          method: :post, data: { confirm: job.confirmation_dialog } %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <div class="panel-title">Job Log</div>
-  </div>
-  <div class="panel-body">
-
-    <table data-toggle="table">
-      <thead>
-      <tr>
-        <th data-sortable="true">Job Name</th>
-        <th data-sortable="true">Date Run</th>
-        <th>Time Elapsed</th>
-        <th>Summary</th>
-      </tr>
-      </thead>
-      <tbody>
-      <!--   Display last 10 completed jobs   -->
-      <% CompletedJob.last_ten_jobs(nil).each do |completed_job| %>
-        <tr>
-          <td><%= completed_job.job_name %></td>
-          <td><%= completed_job.created_at %></td>
-          <td><%= completed_job.time_elapsed %></td>
-          <td><%= completed_job.summary %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-
-  </div>
-</div>
+<%= react_component("JobLog", prerender: false, props: {
+    completed_jobs_list: CompletedJob.last_ten_jobs(nil)
+}) %>
 
 <div class="panel panel-default">
   <div class="panel-heading">

--- a/app/views/courses/jobs.html.erb
+++ b/app/views/courses/jobs.html.erb
@@ -1,59 +1,11 @@
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <div class="panel-title">Jobs</div>
-  </div>
-  <div class="panel-body">
+<%= react_component("JobLauncher", prerender: false, props: {
+    jobs_list: course_job_info_list,
+    run_url_prefix: "/courses/#{@course.id}/run_course_job"
+}) 
+%>
+<%= react_component("JobLog", prerender: false, props: {
+    completed_jobs_list: CompletedJob.last_ten_jobs(@course.id)
+}) 
+%>
 
-    <table class="table">
-      <thead>
-      <tr>
-        <th>Job Name</th>
-        <th>Last Run</th>
-        <th colspan="1"></th>
-      </tr>
-      </thead>
-      <tbody>
-      <% course_job_list.each do |job| %>
-        <tr>
-          <td><span class="job_name" data-toggle="tooltip" title = "<%= job.job_description %>"><%= job.job_name %></span></td>
-          <td><%= job.last_run %></td>
-          <td><%= link_to 'Run Job', course_run_course_job_path(@course, job_name: job.job_short_name),
-                          method: :post %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
 
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <div class="panel-title">Job Log</div>
-  </div>
-  <div class="panel-body">
-
-    <table data-toggle="table">
-      <thead>
-      <tr>
-        <th data-sortable="true">Job Name</th>
-        <th data-sortable="true">Date Run</th>
-        <th>Time Elapsed</th>
-        <th>Summary</th>
-      </tr>
-      </thead>
-      <tbody>
-      <!--   Display last 10 completed jobs   -->
-      <% CompletedJob.last_ten_jobs(@course.id).each do |completed_job| %>
-        <tr>
-          <td><%= completed_job.job_name %></td>
-          <td><%= completed_job.created_at %></td>
-          <td><%= completed_job.time_elapsed %></td>
-          <td><%= completed_job.summary %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-
-  </div>
-</div>


### PR DESCRIPTION
In this PR, we replace the job launcher and job log panels with React Components.

This PR is mostly refactoring; there are no major user facing changes.

Benefits:
* Remove duplication of code between Admin and Course views.
* Make it easier to add jobs to other elements in the app (we anticipate possibly a job at the repo level)

Minor User Facing Changes:
* The Course level Test job now has a confirmation dialog; this is helpful for testing.
* The timestamps have a slightly different (and more user friendly) format.

