### PR TITLE
Add page to list github repos for a Course

### DIFF
--- a/app/controllers/api/courses/github_repos_controller.rb
+++ b/app/controllers/api/courses/github_repos_controller.rb
@@ -5,7 +5,16 @@ module Api::Courses
     load_and_authorize_resource
 
     def index
-      respond_with @course.github_repos
+        @github_repos = @course.github_repos.all
+        search_query = params[:search]
+        visibility_query = params[:visibility]
+        unless search_query.nil? || search_query.empty?
+          @github_repos = @github_repos.where("name LIKE ?", "%#{search_query}%")
+        end
+        unless visibility_query.nil? || visibility_query.empty?
+          @github_repos = @github_repos.where(visibility: visibility_query)
+        end
+        paginate json: @github_repos
     end
 
     def show

--- a/app/controllers/api/courses/github_repos_controller.rb
+++ b/app/controllers/api/courses/github_repos_controller.rb
@@ -1,0 +1,15 @@
+module Api::Courses
+  class GithubReposController < ApplicationController
+    respond_to :json
+    load_and_authorize_resource :course
+    load_and_authorize_resource
+
+    def index
+      respond_with @course.github_repos
+    end
+
+    def show
+      respond_with @github_repo
+    end
+  end
+end

--- a/app/controllers/courses/github_repos_controller.rb
+++ b/app/controllers/courses/github_repos_controller.rb
@@ -1,0 +1,37 @@
+# This controller is nested in the routing hierarchy as a child controller of 
+# courses_controller
+# see this tutorial for details on how we do this https://gist.github.com/jhjguxin/3074080
+require 'Octokit_Wrapper'
+
+module Courses
+  class GithubReposController < ApplicationController
+    layout 'courses'
+    before_action :load_parent
+    before_action :set_github_repo, only: [:show]
+
+    load_and_authorize_resource :course
+    load_and_authorize_resource :github_repo, through: :course
+
+    def index
+      @github_repos = @parent.github_repos.all
+    end
+
+    def show
+    end
+
+    private
+      # Use callbacks to share common setup or constraints between actions.
+      def set_github_repo
+        @github_repo = GithubRepo.find(params[:id])
+      end
+
+      def machine_user
+        client = Octokit_Wrapper::Octokit_Wrapper.machine_user
+      end
+
+      def load_parent
+        @parent = Course.find(params[:course_id])
+      end
+  end
+
+end

--- a/app/javascript/components/Course/GithubRepos/CourseGithubRepo.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubRepo.jsx
@@ -1,0 +1,38 @@
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+import { Table } from "react-bootstrap";
+import CourseGithubReposTable from "./CourseGithubReposTable";
+
+import axios from "../../../helpers/axios-rails";
+import ReposService from "../../../services/repos-service";
+
+class CourseGithubRepo extends Component {
+
+    constructor(props) {
+        super(props);
+        const csrfToken = ReactOnRails.authenticityToken();
+        axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+        axios.defaults.params = {}
+        axios.defaults.params['authenticity_token'] = csrfToken;
+
+    }
+
+    componentDidMount() {
+        console.log("CourseGithubReposIndex componentDidMount called");
+    }
+
+
+    render() {
+        return (
+            <Fragment>
+                <CourseGithubReposTable repos={[this.props.repo]} {...this.props} />
+            </Fragment>
+        );
+    }
+}
+
+CourseGithubRepo.propTypes = {
+
+};
+
+export default CourseGithubRepo;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubRepo.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubRepo.jsx
@@ -10,29 +10,29 @@ class CourseGithubRepo extends Component {
 
     constructor(props) {
         super(props);
-        const csrfToken = ReactOnRails.authenticityToken();
-        axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
-        axios.defaults.params = {}
-        axios.defaults.params['authenticity_token'] = csrfToken;
-
     }
 
     componentDidMount() {
         console.log("CourseGithubReposIndex componentDidMount called");
     }
 
-
     render() {
         return (
             <Fragment>
-                <CourseGithubReposTable repos={[this.props.repo]} {...this.props} />
+                <CourseGithubReposTable
+                    repos={[this.props.repo]}
+                    page={1}
+                    pageSize={1}
+                    totalSize={1}
+                    {...this.props}
+                />
             </Fragment>
         );
     }
 }
 
 CourseGithubRepo.propTypes = {
-
+    repo : PropTypes.object.isRequired
 };
 
 export default CourseGithubRepo;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposControls.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposControls.jsx
@@ -1,0 +1,43 @@
+import React, { Fragment, Component } from 'react';
+import PropTypes from 'prop-types';
+import { Col, Form, FormControl, FormGroup, ControlLabel, Radio } from "react-bootstrap";
+
+class CourseGithubReposControls extends Component {
+    render() {
+        return (
+            <Form horizontal>
+                <FormGroup >
+                    <Col xs={3}>
+                    <ControlLabel >Visibility</ControlLabel>
+
+                    <FormControl
+                        
+                        componentClass="select"
+                        onChange={(event) => { this.props.onVisibilityChanged(event.target.value) }}>
+                        <option value="">All</option>
+                        <option value="public">Public</option>
+                        <option value="private">Private</option>
+                    </FormControl>
+                    </Col>
+               
+                <Col xs={9}>
+                    <ControlLabel >Search</ControlLabel>
+                    <FormControl
+                        
+                        type="text"
+                        placeholder="Search repo names"
+                        onChange={(event) => { this.props.onSearchChanged(event.target.value) }}
+                    />
+                    </Col>
+                </FormGroup>
+            </Form>
+        );
+    }
+}
+
+CourseGithubReposControls.propTypes = {
+    onSearchChanged: PropTypes.func.isRequired,
+    onVisibilityChanged: PropTypes.func.isRequired
+};
+
+export default CourseGithubReposControls;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
@@ -25,7 +25,7 @@ class CourseGithubReposIndex extends Component {
         if (searchValue === this.props.search) {
             return;
         }
-        this.setState({search: searchValue}, () => {
+        this.setState({page: 1, search: searchValue}, () => {
             this.updateRepos();
         });
     }
@@ -34,7 +34,8 @@ class CourseGithubReposIndex extends Component {
         if (visibilityValue === this.props.visibility) {
             return;
         }
-        this.setState({visibility: visibilityValue}, () => {
+
+        this.setState({page: 1, visibility: visibilityValue}, () => {
            this.updateRepos();
         });
     }
@@ -106,7 +107,7 @@ class CourseGithubReposIndex extends Component {
 CourseGithubReposIndex.propTypes = {
     search: PropTypes.string,
     type: PropTypes.string,
-    course_id : PropTypes.string.isRequired
+    course_id : PropTypes.number.isRequired
 };
 
 export default CourseGithubReposIndex;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
@@ -1,21 +1,19 @@
 import React, { Component, Fragment } from 'react';
-import * as PropTypes from 'prop-types';
-import { Table } from "react-bootstrap";
+import PropTypes from 'prop-types';
 import CourseGithubReposTable from "./CourseGithubReposTable";
 import CourseGithubReposControls from "./CourseGithubReposControls";
 
 import axios from "../../../helpers/axios-rails";
-import ReposService from "../../../services/repos-service";
+import { Alert, Form } from 'react-bootstrap';
+import {debounce} from "debounce";
+
+import { githubReposRoute } from "../../../services/service-routes";
 
 class CourseGithubReposIndex extends Component {
-
     constructor(props) {
         super(props);
-        const csrfToken = ReactOnRails.authenticityToken();
-        axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
-        axios.defaults.params = {}
-        axios.defaults.params['authenticity_token'] = csrfToken;
-        this.state = { repos: [] };
+        this.state = { search: this.props.search ?? "", type: this.props.visibility ?? "", error: "", repos: [], page: 1, pageSize: 25, totalSize: 0 };
+        this.onSearchChanged = debounce(this.onSearchChanged, 1000);
     }
 
     componentDidMount() {
@@ -23,31 +21,92 @@ class CourseGithubReposIndex extends Component {
         this.updateRepos();
     }
 
+    onSearchChanged = (searchValue) => {
+        if (searchValue === this.props.search) {
+            return;
+        }
+        this.setState({search: searchValue}, () => {
+            this.updateRepos();
+        });
+    }
+
+    onVisibilityChanged = (visibilityValue) => {
+        if (visibilityValue === this.props.visibility) {
+            return;
+        }
+        this.setState({visibility: visibilityValue}, () => {
+           this.updateRepos();
+        });
+    }
+
+    paginationHandler = (page, pageSize) => {
+        this.setState({page: page, pageSize: pageSize}, () => {
+            this.updateRepos();
+        });
+    }
+
     updateRepos = () => {
         console.log("CourseGithubReposIndex updateRepos called");
         console.log("this.props=" + JSON.stringify(this.props));
 
-        ReposService.getGithubRepos(this.props.course_id).then(reposResponse => {
-            console.log("updateRepos setting state");
-            this.setState({ repos: reposResponse });
+        const url = githubReposRoute(this.props.course_id);
+        const params = {search: this.state.search, visibility: this.state.visibility, page: this.state.page, per_page: this.state.pageSize};
+        // Otherwise, calling setState fails because the scope for "this" is the success/error function.
+        const self = this;
+        Rails.ajax({
+            url: url,
+            type: "get",
+            data: $.param(params),
+            beforeSend: function() {
+                return true;
+            },
+            success: function (data, status, xhr) {
+                const totalRecords = parseInt(xhr.getResponseHeader("X-Total"));
+                const page = parseInt(xhr.getResponseHeader("X-Page"));
+                self.setState({ repos: data, totalSize: totalRecords, page: page, error: "" });
+            },
+            error: function (data) {
+                self.setState({ error: data });
+            }
         });
-    };
+    }
+
+    renderError() { // Or don't
+        const error = this.state.error;
+        return (
+            <div>
+            { error !== "" &&
+                <Alert id="error-alert" variant="danger"> {error} </Alert>
+            }
+            </div>
+        );
+    }
 
     render() {
         return (
-            <Fragment>
+            <div>
+                { this.renderError() }
                 <CourseGithubReposControls 
-                onSearchChanged={ ()=>{} }
-                onVisibilityChanged={ ()=>{}}
+                    onSearchChanged={this.onSearchChanged}
+                    onVisibilityChanged={this.onVisibilityChanged}
                 />
-                <CourseGithubReposTable repos={this.state.repos} {...this.props} />
-            </Fragment>
+                <CourseGithubReposTable
+                    repos={this.state.repos}
+                    page={this.state.page}
+                    pageSize={this.state.pageSize}
+                    totalSize={this.state.totalSize}
+                    paginationHandler={this.paginationHandler}
+                    {...this.props}
+                />
+            </div>
         );
     }
 }
 
 CourseGithubReposIndex.propTypes = {
-
+    search: PropTypes.string,
+    type: PropTypes.string,
+    course_id : PropTypes.string.isRequired
 };
 
 export default CourseGithubReposIndex;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
@@ -2,6 +2,8 @@ import React, { Component, Fragment } from 'react';
 import * as PropTypes from 'prop-types';
 import { Table } from "react-bootstrap";
 import CourseGithubReposTable from "./CourseGithubReposTable";
+import CourseGithubReposControls from "./CourseGithubReposControls";
+
 import axios from "../../../helpers/axios-rails";
 import ReposService from "../../../services/repos-service";
 
@@ -34,6 +36,10 @@ class CourseGithubReposIndex extends Component {
     render() {
         return (
             <Fragment>
+                <CourseGithubReposControls 
+                onSearchChanged={ ()=>{} }
+                onVisibilityChanged={ ()=>{}}
+                />
                 <CourseGithubReposTable repos={this.state.repos} {...this.props} />
             </Fragment>
         );

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposIndex.jsx
@@ -1,0 +1,47 @@
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+import { Table } from "react-bootstrap";
+import CourseGithubReposTable from "./CourseGithubReposTable";
+import axios from "../../../helpers/axios-rails";
+import ReposService from "../../../services/repos-service";
+
+class CourseGithubReposIndex extends Component {
+
+    constructor(props) {
+        super(props);
+        const csrfToken = ReactOnRails.authenticityToken();
+        axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+        axios.defaults.params = {}
+        axios.defaults.params['authenticity_token'] = csrfToken;
+        this.state = { repos: [] };
+    }
+
+    componentDidMount() {
+        console.log("CourseGithubReposIndex componentDidMount called");
+        this.updateRepos();
+    }
+
+    updateRepos = () => {
+        console.log("CourseGithubReposIndex updateRepos called");
+        console.log("this.props=" + JSON.stringify(this.props));
+
+        ReposService.getGithubRepos(this.props.course_id).then(reposResponse => {
+            console.log("updateRepos setting state");
+            this.setState({ repos: reposResponse });
+        });
+    };
+
+    render() {
+        return (
+            <Fragment>
+                <CourseGithubReposTable repos={this.state.repos} {...this.props} />
+            </Fragment>
+        );
+    }
+}
+
+CourseGithubReposIndex.propTypes = {
+
+};
+
+export default CourseGithubReposIndex;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposRow.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposRow.jsx
@@ -1,0 +1,21 @@
+import React, { Component, Fragment } from 'react';
+import * as PropTypes from 'prop-types';
+
+class CourseGithubReposRow extends Component {
+    render() {
+        const r = this.props.repo; // Save some characters
+        return (
+            <tr key={r.id}>
+                <td><a href={`/courses/${this.props.course_id}/github_repos/${r.id}`}>{r.name}</a></td>
+                <td><a href={r.url}>on Github</a></td>
+                <td>{r.visibility}</td>
+            </tr>
+        );
+    }
+}
+
+CourseGithubReposRow.propTypes = {
+    repo: PropTypes.object.isRequired
+};
+
+export default CourseGithubReposRow;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposTable.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposTable.jsx
@@ -1,0 +1,35 @@
+import React, { Component, Fragment } from 'react';
+import { Table } from "react-bootstrap";
+import CourseGithubReposRow from "./CourseGithubReposRow";
+
+class CourseGithubReposTable extends Component {
+
+    render() {
+        return (
+            <Fragment>
+                <div class="panel panel-default">
+                    <Table striped hover>
+                        <thead>
+                            <tr>
+                                <th>name</th>
+                                <th>on GitHub</th>
+                                <th>visibility</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.props.repos.map(repo =>
+                                <CourseGithubReposRow repo={repo} key={repo.id} {...this.props} />
+                            )}
+                        </tbody>
+                    </Table>
+                </div>
+            </Fragment>
+        );
+    }
+}
+
+CourseGithubReposTable.propTypes = {
+
+};
+
+export default CourseGithubReposTable;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposTable.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposTable.jsx
@@ -1,35 +1,95 @@
 import React, { Component, Fragment } from 'react';
 import { Table } from "react-bootstrap";
+import BootstrapTable from 'react-bootstrap-table-next';
 import CourseGithubReposRow from "./CourseGithubReposRow";
+import PropTypes from 'prop-types';
+import paginationFactory from 'react-bootstrap-table2-paginator';
+
+import { githubRepoRoute } from "../../../services/service-routes";
 
 class CourseGithubReposTable extends Component {
 
+    constructor(props) {
+        super(props);
+    }
+
+    columns =
+        [{
+            dataField: 'name',
+            text: 'Name',
+            editable: false,
+            formatter: (cell, row, rowIndex, extraData) => this.renderRepoShowPageUrl(cell, row, rowIndex, {"course_id": this.props.course_id})
+        }, {
+            dataField: 'url',
+            text: 'on Github',
+            editable: false,
+            formatter: (cell) => this.renderRepoGithubUrl(cell)
+        }, {
+            dataField: 'visibility',
+            text: 'Visibility',
+            editable: false
+        }];
+
+    renderRepoShowPageUrl = (cell, row, rowIndex, extraData) => {
+        console.log("renderRepoShowPageUrl");
+        console.log("row="+JSON.stringify(row));
+        const url = `/courses/${extraData.course_id}/github_repos/${row.id}`;
+        return (
+            <a href={url}>{cell}</a>
+        );
+    }
+
+    renderRepoGithubUrl = (cell) => {
+        return (
+            <a href={cell}>on Github</a>
+        );
+    }
+
+    onTableChange = (type, newState) => {
+        if (type !== "pagination") {
+            // For now, sort and filter are disabled.
+            return;
+        }
+        this.props.paginationHandler(newState.page, newState.sizePerPage);
+    }
+
+    paginationOptions = () => {
+        return paginationFactory({
+            totalSize: this.props.totalSize,
+            page: this.props.page,
+            sizePerPage: this.props.pageSize
+        });
+    }
+
     render() {
+        console.log("CourseGithubReposTable render");
+        console.log("this.props.repos="+JSON.stringify(this.props.repos));
         return (
             <Fragment>
-                <div className="panel panel-default">
-                    <Table striped hover>
-                        <thead>
-                            <tr>
-                                <th>name</th>
-                                <th>on GitHub</th>
-                                <th>visibility</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {this.props.repos.map(repo =>
-                                <CourseGithubReposRow repo={repo} key={repo.id} {...this.props} />
-                            )}
-                        </tbody>
-                    </Table>
-                </div>
+                <BootstrapTable
+                    columns={this.columns}
+                    data={this.props.repos}
+                    keyField="id"
+                    remote={ { pagination: true, filter: false, sort: false } }
+                    pagination={ 
+                        this.props.paginationHandler ?
+                        this.paginationOptions()  : 
+                        undefined
+                    }
+                    onTableChange={ this.onTableChange }
+                    hidePageListOnlyOnePage={true}
+                />
             </Fragment>
         );
     }
 }
 
 CourseGithubReposTable.propTypes = {
-
+    repos: PropTypes.array.isRequired,
+    paginationHandler: PropTypes.func,
+    page: PropTypes.number.isRequired,
+    pageSize: PropTypes.number.isRequired,
+    totalSize: PropTypes.number.isRequired
 };
 
 export default CourseGithubReposTable;

--- a/app/javascript/components/Course/GithubRepos/CourseGithubReposTable.jsx
+++ b/app/javascript/components/Course/GithubRepos/CourseGithubReposTable.jsx
@@ -7,7 +7,7 @@ class CourseGithubReposTable extends Component {
     render() {
         return (
             <Fragment>
-                <div class="panel panel-default">
+                <div className="panel panel-default">
                     <Table striped hover>
                         <thead>
                             <tr>

--- a/app/javascript/components/CourseNavBar/CourseNavBar.jsx
+++ b/app/javascript/components/CourseNavBar/CourseNavBar.jsx
@@ -1,6 +1,6 @@
-import React, {Component, Fragment} from 'react';
+import React, { Component, Fragment } from 'react';
 import * as PropTypes from 'prop-types';
-import {Row, Col, MenuItem, Tab, Nav, NavItem, NavDropdown, Button} from "react-bootstrap";
+import { Row, Col, MenuItem, Tab, Nav, NavItem, NavDropdown, Button } from "react-bootstrap";
 
 class CourseNavBar extends Component {
     currentActiveTab = (currentPath) => {
@@ -31,6 +31,7 @@ class CourseNavBar extends Component {
                         <MenuItem eventKey="create_repos" href={this.props.create_team_repos_path}>Create Team Repos</MenuItem>
                     </NavDropdown>
                     <NavDropdown title="Repos">
+                        <MenuItem eventKey="github_repos" href={this.props.github_repos_path}>All Repos</MenuItem>
                         <MenuItem eventKey="repos" href={this.props.repos_path}>Repo Search</MenuItem>
                     </NavDropdown>
                     <NavItem eventKey="events" href={this.props.events_path}>Events</NavItem>
@@ -49,6 +50,7 @@ CourseNavBar.propTypes = {
     project_teams_path: PropTypes.string.isRequired,
     org_teams_path: PropTypes.string.isRequired,
     repos_path: PropTypes.string.isRequired,
+    github_repos_path: PropTypes.string.isRequired,
     events_path: PropTypes.string.isRequired,
     slack_path: PropTypes.string.isRequired,
     jobs_path: PropTypes.string.isRequired,

--- a/app/javascript/packs/react-bundle.js
+++ b/app/javascript/packs/react-bundle.js
@@ -4,11 +4,17 @@ import Users from '../components/Users/Users';
 import ProjectTeams from "../components/ProjectTeams/ProjectTeams";
 import CourseNavBar from "../components/CourseNavBar/CourseNavBar";
 import StudentActivity from "../components/ActivityDashboard/Student/StudentActivity";
+import CourseGithubReposIndex from "../components/Course/GithubRepos/CourseGithubReposIndex";
+import CourseGithubRepo from "../components/Course/GithubRepos/CourseGithubRepo";
+
+
 import "../styles.css"
 
 ReactOnRails.register({
   Users,
   ProjectTeams,
   CourseNavBar,
-  StudentActivity
+  StudentActivity,
+  CourseGithubReposIndex,
+  CourseGithubRepo
 });

--- a/app/javascript/services/repos-service.js
+++ b/app/javascript/services/repos-service.js
@@ -1,0 +1,15 @@
+import axios from '../helpers/axios-rails';
+import {githubReposRoute, githubRepoRoute} from "./service-routes";
+
+class ReposService {
+    static async getGithubRepos(courseId) {
+        return axios.get(githubReposRoute(courseId)).then(response => response.data);
+    }
+
+    static async getGithubRepo(courseId, githubRepoId) {
+        return axios.get(githubRepoRoute(courseId, githubRepoId)).then(response => response.data);
+    }
+
+}
+
+export default ReposService;

--- a/app/javascript/services/service-routes.js
+++ b/app/javascript/services/service-routes.js
@@ -2,6 +2,7 @@ const courseRoute = (courseId) => `/api/courses/${courseId}`;
 const courseProjectTeamsRoute = (courseId) => `${courseRoute(courseId)}/project_teams`
 const courseOrgTeamsRoute = (courseId) => `${courseRoute(courseId)}/org_teams`
 const courseStudentsRoute = (courseId) => `${courseRoute(courseId)}/roster_students`
+const courseGithubReposRoute = (courseId) => `${courseRoute(courseId)}/github_repos`
 
 export const projectTeamsRoute = (courseId) => `${courseProjectTeamsRoute(courseId)}`
 export const projectTeamRoute = (courseId, projectTeamId) => `${courseProjectTeamsRoute(courseId)}/${projectTeamId}`
@@ -12,3 +13,6 @@ export const studentRoute = (courseId, rosterStudentId) => `${courseStudentsRout
 export const studentActivityRoute = (courseId, rosterStudentId) => `${studentRoute(courseId, rosterStudentId)}/activity`
 
 export const studentUiRoute = (courseId, studentId) => `/courses/${courseId}/roster_students/${studentId}`
+
+export const githubReposRoute = (courseId) => `${courseGithubReposRoute(courseId)}`
+export const githubRepoRoute = (courseId, githubRepoId) => `${courseGithubReposRoute(courseId)}/${githubRepoId}`

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -9,7 +9,7 @@ class Course < ApplicationRecord
   validate :check_course_org_exists
   has_many :roster_students, dependent: :destroy
   has_many :completed_jobs, dependent: :destroy
-  has_many :github_repos, dependent: :destroy
+  has_many :github_repos, dependent: :destroy, class_name: '::GithubRepo'
   has_many :org_teams, dependent: :destroy
   has_one :slack_workspace, dependent: :destroy
   has_one :org_webhook, dependent: :destroy

--- a/app/views/courses/github_repos/index.html.erb
+++ b/app/views/courses/github_repos/index.html.erb
@@ -1,0 +1,8 @@
+<%= react_component("CourseGithubReposIndex",
+                        props: {current_path: request.env['PATH_INFO'], 
+                                can_edit: can?(:update, @course),
+                                course_id: params[:course_id].to_i,
+                                course: @parent
+                        },
+                        prerender: false) 
+%>

--- a/app/views/courses/github_repos/show.html.erb
+++ b/app/views/courses/github_repos/show.html.erb
@@ -1,0 +1,11 @@
+<%= react_component("CourseGithubRepo",
+                        props: {current_path: request.env['PATH_INFO'], 
+                                can_edit: can?(:update, @course),
+                                course_id: params[:course_id].to_i,
+                                course: @parent,
+                                repo: @github_repo
+                        },
+                        prerender: false) 
+%>
+
+

--- a/app/views/layouts/courses.html.erb
+++ b/app/views/layouts/courses.html.erb
@@ -8,7 +8,8 @@
                                 jobs_path: course_jobs_path(@course), edit_path: edit_course_path(@course),
                                 create_team_repos_path: create_repos_course_org_teams_path(@course),
                                 create_teams_path: create_teams_course_org_teams_path(@course), events_path: course_events_path(@course),
-                                can_edit: can?(:update, @course)
+                                can_edit: can?(:update, @course),
+                                github_repos_path: course_github_repos_path(@course) 
                         },
                         prerender: false) %>
     <br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       scope module: :courses do
         resources :project_teams
         resources :org_teams
+        resources :github_repos
         resources :roster_students do
           get :activity
           get :commits
@@ -41,6 +42,7 @@ Rails.application.routes.draw do
         end
         get :activity
       end
+      resources :github_repos
       resources :org_teams do
         collection do
           get :create_repos


### PR DESCRIPTION
In this PR, we add a page that allows the user to list all repos for a course.  

This is done with pagination, and with a filter by repo name, and a filter for visibility (All, Public, Private).

Each repo also now has a "show page" (i.e. you can click on any repo, and go to a page in the app that displays
information just for that repo.)

This is a preliminary step for future work that is NOT in this PR:
* being able to setup a page to run jobs against a repo to load all commits for that repo's master branch into the database
* allowing the user to download those commits to a CSV