### PR TITLE
pc - fix job elapsed time for in progress jobs

### DIFF
--- a/app/models/completed_job.rb
+++ b/app/models/completed_job.rb
@@ -8,7 +8,7 @@ include ActionView::Helpers::DateHelper
 class CompletedJob < ApplicationRecord
 
   def time_elapsed
-    return distance_of_time_in_words_to_now(created_at, include_seconds: true) if summary == "In progress"
+    return distance_of_time_in_words(created_at, Time.zone.now, include_seconds: true) if summary == "In progress"
     distance_of_time_in_words(created_at, updated_at, include_seconds: true)
   end
 


### PR DESCRIPTION
Because distance_of_time_in_words_to_now doesn't respect daylight savings time,
use distance_of_time_in_words with Time.zone.now instead

Fixes issue #270