### PR TITLE
pc - fix bug where enabling webhooks on a new course fails

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,7 +16,7 @@ class Course < ApplicationRecord
   has_many :org_webhook_events, dependent: :destroy
   has_many :project_teams
 
-  before_save :update_org_webhook, if: :will_save_change_to_github_webhooks_enabled?
+  after_save :update_org_webhook, if: :will_save_change_to_github_webhooks_enabled?
   before_destroy :remove_webhook_from_course_org
 
   resourcify


### PR DESCRIPTION
This is a simple one line change to fix a bug.

* STR: Try to create a new course, and select webhooks enabled on create.
* Observed: Crashes
* Desired: Successfully creates course with web hooks enabled.

The key is to run the update_org_webhook method as an after_save rather than a before_save.
That way, you already have a course id.  You must have a course id in order to know what
the url will be for the webhooks.