### PR TITLE
pc - upgrade bootstrap because of GitHub security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@rails/webpacker": "4.2.2",
     "axios": "^0.19.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "css-loader": "^3.5.3",
     "debounce": "^1.2.0",
     "immutability-helper": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,10 +1605,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Based on this security warning:

```
Bump bootstrap from 3.3.7 to 3.4.1  dependencies javascript
#252 by dependabot bot was closed on May 21
 1
5 bootstrap vulnerabilities found in yarn.lock on May 21
Remediation
Upgrade bootstrap to version 3.4.1 or later. For example:

bootstrap@^3.4.1:
  version "3.4.1"
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2019-8331
moderate severity
Vulnerable versions: >= 3.0.0, < 3.4.1
Patched version: 3.4.1
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/

CVE-2018-20677
low severity
Vulnerable versions: < 3.4.0
Patched version: 3.4.0
In Bootstrap before 3.4.0, XSS is possible in the affix configuration target property.

CVE-2018-20676
low severity
Vulnerable versions: < 3.4.0
Patched version: 3.4.0
In Bootstrap before 3.4.0, XSS is possible in the tooltip data-viewport attribute.

CVE-2016-10735
low severity
Vulnerable versions: >= 3.0.0, < 3.4.0
Patched version: 3.4.0
In Bootstrap 3.x before 3.4.0 and 4.x-beta before 4.0.0-beta.2, XSS is possible in the data-target attribute. Note that this is a different vulnerability than CVE-2018-14041.

See https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/ for more info.

CVE-2018-14041
moderate severity
Vulnerable versions: < 3.4.0
Patched version: 3.4.0
In Bootstrap before 4.1.2, XSS is possible in the data-target property of scrollspy. This is similar to CVE-2018-14042.
```