### PR TITLE
Feature toggle with flipper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,3 +122,8 @@ gem "activesupport", ">= 5.2.4.3"
 group :development, :test do
   gem 'factory_bot_rails'
 end
+
+# Feature toggle (see: https://github.com/jnunemaker/flipper)
+gem 'flipper'
+gem 'flipper-ui'
+gem 'flipper-active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,15 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.13.1)
+    flipper (0.18.0)
+    flipper-active_record (0.18.0)
+      activerecord (>= 5.0, < 7)
+      flipper (~> 0.18.0)
+    flipper-ui (0.18.0)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.18.0)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.1.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     github_webhook (1.1.2)
@@ -203,6 +212,8 @@ GEM
     public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.3)
+    rack-protection (2.0.8.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -342,6 +353,9 @@ DEPENDENCIES
   dotenv-rails
   dotiw
   factory_bot_rails
+  flipper
+  flipper-active_record
+  flipper-ui
   font-awesome-rails
   github_webhook (~> 1.1)
   jbuilder (~> 2.5)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,6 +8,11 @@ class AdminController < ApplicationController
       authorize! :manage, :all
     end
 
+    def flipper_features
+      Flipper.features.map{|f| {name: f.name, enabled: Flipper.enabled?(f.name.to_sym,current_user)} }
+    end
+    helper_method :flipper_features
+
     # This is an intricate bit of code that formats the results of this really messed up SQL query into a dictionary
     # of table names and their corresponding row counts.
     # Source of query: https://stackoverflow.com/a/42121447/3950780

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -275,6 +275,8 @@ class Course < ApplicationRecord
     GRAPHQL
   end
   
-
+  def self.all_course_names
+      Course.all.map{|c| c.name}
+  end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,6 +77,11 @@ class User < ApplicationRecord
     self.roster_students.map { |student| student.course }
   end
 
+  def enrolled_in?(course_name)
+    course_names = courses.map{|c| c.name}
+    course_names.include?(course_name)
+  end
+
   def courses_administrating
     if has_role? :user
       return []

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,4 +150,7 @@ class User < ApplicationRecord
     users.joins(:roles).where("roles.name = ?", role_str).where("roles.resource_id is null")
   end
 
+  def flipper_id
+    return username
+  end
 end

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -66,3 +66,29 @@
 
   </div>
 </div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <div class="panel-title">Feature Toggles (Flipper)</div>
+  </div>
+  <div class="panel-body">
+
+    <table class="table">
+      <thead>
+      <tr>
+        <th>Feature</th>
+        <th>Enabled</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% flipper_features.each do |f| %>
+        <tr>
+          <td><%= f[:name] %></td>
+          <td><%= f[:enabled] %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+  </div>
+</div>

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -69,7 +69,10 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <div class="panel-title">Feature Toggles (Flipper)</div>
+    <div class="btn-group pull-right">
+      <%= link_to "Flipper Panel", "/admin/flipper", method: :get, class: "btn btn-danger" %>
+    </div>
+    <h4>Feature Toggles (Flipper)</h4>
   </div>
   <div class="panel-body">
 

--- a/config/initializers/admin_access.rb
+++ b/config/initializers/admin_access.rb
@@ -1,0 +1,8 @@
+# Protect flipper endpoint so that it is only accessible by admins
+# https://github.com/jnunemaker/flipper/blob/master/docs/ui/README.md
+class CanAccessFlipperUI
+    def self.matches?(request)
+      current_user = request.env['warden'].user
+      current_user.present? && current_user.respond_to?(:has_role?) && current_user.has_role?(:admin) 
+    end
+end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,6 +1,12 @@
 require 'flipper'
 require 'flipper/adapters/active_record'
 
+# ADD NEW FEATURES TO THE ARRAY BELOW
+
+features = [
+  'assignments' 
+]
+
 Flipper.configure do |config|
   config.default do
     adapter = Flipper::Adapters::ActiveRecord.new
@@ -10,3 +16,26 @@ Flipper.configure do |config|
   end
 end
 
+Flipper::UI.configure do |config|
+  config.fun = false
+  config.banner_text = "Rails.env=#{Rails.env}"
+  config.banner_class = 'danger'
+end
+
+# This setup is primarily for first deployment, because consequently 
+# we can add new features from the Web UI. However when the DB is changed/crashed
+# or in dev mode. This will immediately migrate the default features to be controlled. 
+def setup_features(features)
+  features.each do |feature|
+    if Flipper[feature].exist?
+      return
+    end
+    
+    # Disable feature by default
+    Flipper[feature].disable
+  end
+end
+
+if ActiveRecord::Base.connection.data_source_exists? 'flipper_features'
+  setup_features(features)
+end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -36,14 +36,20 @@ def setup_features(features)
   end
 end
 
-if ActiveRecord::Base.connection.data_source_exists? 'flipper_features'
-  setup_features(features)
-end
-
-# Register all course names as groups
-
-Course.all_course_names.each do |course_name|
-  Flipper.register(course_name) do |actor|
-    actor.respond_to?(:enrolled_in?) && actor.enrolled_in?(course_name)
+def register_course_names_as_groups
+  Course.all_course_names.each do |course_name|
+    Flipper.register(course_name) do |actor|
+      actor.respond_to?(:enrolled_in?) && actor.enrolled_in?(course_name)
+    end
   end
 end
+
+if Rails.env!="test" && ActiveRecord::Base.connection.data_source_exists?('flipper_features')
+  # For Rails.env=="test", the database doesn't exists 
+  # yet when initializers are run.  But that's ok; we don't need
+  # this setup in a test environment.  You'd probably mock or stub the
+  # feature toggle being on/off if you depend on that for a test.
+  setup_features(features)
+  register_course_names_as_groups
+end
+

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,12 @@
+require 'flipper'
+require 'flipper/adapters/active_record'
+
+Flipper.configure do |config|
+  config.default do
+    adapter = Flipper::Adapters::ActiveRecord.new
+
+    # pass adapter to handy DSL instance
+    Flipper.new(adapter)
+  end
+end
+

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -39,3 +39,11 @@ end
 if ActiveRecord::Base.connection.data_source_exists? 'flipper_features'
   setup_features(features)
 end
+
+# Register all course names as groups
+
+Course.all_course_names.each do |course_name|
+  Flipper.register(course_name) do |actor|
+    actor.respond_to?(:enrolled_in?) && actor.enrolled_in?(course_name)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
 
   constraints CanAccessFlipperUI do
-    mount Flipper::UI.app(Flipper) => '/flipper'
+    mount Flipper::UI.app(Flipper) => '/admin/flipper'
   end
 
   namespace :api, :defaults => { :format => 'json' } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     get 'sign_out', :to => 'devise/sessions#destroy', :as => :signout
   end
 
+  constraints CanAccessFlipperUI do
+    mount Flipper::UI.app(Flipper) => '/flipper'
+  end
+
   namespace :api, :defaults => { :format => 'json' } do
 
     match 'testhooks/login_student' => 'testhooks#login_student', :via => :get

--- a/db/migrate/20200824183703_create_flipper_tables.rb
+++ b/db/migrate/20200824183703_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200721005709) do
+ActiveRecord::Schema.define(version: 2020_08_24_183703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,11 +22,9 @@ ActiveRecord::Schema.define(version: 20200721005709) do
     t.bigint "course_id"
     t.string "summary"
     t.string "job_short_name"
-    t.bigint "github_repos_id"
     t.bigint "github_repo_id"
     t.index ["course_id"], name: "index_completed_jobs_on_course_id"
     t.index ["github_repo_id"], name: "index_completed_jobs_on_github_repo_id"
-    t.index ["github_repos_id"], name: "index_completed_jobs_on_github_repos_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -36,6 +34,22 @@ ActiveRecord::Schema.define(version: 20200721005709) do
     t.datetime "updated_at", null: false
     t.boolean "hidden"
     t.boolean "github_webhooks_enabled"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "github_repos", force: :cascade do |t|
@@ -48,7 +62,21 @@ ActiveRecord::Schema.define(version: 20200721005709) do
     t.integer "repo_id"
     t.string "full_name"
     t.string "visibility"
+    t.boolean "is_project_repo"
     t.index ["course_id"], name: "index_github_repos_on_course_id"
+  end
+
+  create_table "informed_consents", force: :cascade do |t|
+    t.string "perm"
+    t.string "name"
+    t.bigint "course_id"
+    t.boolean "student_consents"
+    t.bigint "roster_student_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "index_informed_consents_on_course_id"
+    t.index ["perm", "course_id"], name: "index_informed_consents_on_perm_and_course_id", unique: true
+    t.index ["roster_student_id", "course_id"], name: "index_informed_consents_on_roster_student_id_and_course_id", unique: true
   end
 
   create_table "org_teams", force: :cascade do |t|
@@ -117,6 +145,11 @@ ActiveRecord::Schema.define(version: 20200721005709) do
     t.datetime "updated_at", null: false
     t.string "filenames_changed"
     t.boolean "committed_via_web"
+    t.string "author_login"
+    t.string "author_name"
+    t.string "author_email"
+    t.integer "additions"
+    t.integer "deletions"
     t.index ["github_repo_id"], name: "index_repo_commit_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_commit_events_on_roster_student_id"
   end
@@ -137,6 +170,20 @@ ActiveRecord::Schema.define(version: 20200721005709) do
     t.string "action_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "body"
+    t.string "state"
+    t.boolean "closed"
+    t.datetime "closed_at"
+    t.integer "assignee_count"
+    t.string "assignee_logins"
+    t.string "assignee_names"
+    t.integer "project_card_count"
+    t.string "project_card_column_names"
+    t.string "project_card_column_project_names"
+    t.string "project_card_column_project_urls"
+    t.datetime "issue_created_at"
+    t.string "author_login"
     t.index ["github_repo_id"], name: "index_repo_issue_events_on_github_repo_id"
     t.index ["roster_student_id"], name: "index_repo_issue_events_on_roster_student_id"
   end


### PR DESCRIPTION
In this PR, we enable feature toggling using the [flipper gem](https://github.com/jnunemaker/flipper).

This implements the Feature Toggle application development pattern as described on this wikipedia page:
* <https://en.wikipedia.org/wiki/Feature_toggle>

With this PR, admin users can now access an endpoint `/flipper` which provides a UI where individual named features
can be turned on or off for:
* All users
* Specific users (by GitHub id)
* Specific courses (by Course name)

This allows us to put new features into the code base that:
* Might confuse existing users, courses
* Might not be ready for production, but that we want to  start integrating into the code base

The goal is more frequent PRs being merged into master, with less risk.

To execute some code only if a feature is on, use:

```
  if Feature.enabled(:feature_name_as_symbol, current_user)
     # some code here
  end
```

Admin users can see which features are enabled for them by visiting /admin/dashboard and scrolling to the Features section.

# Future work

It might be helpful to add a user information page under the logged in drop down where ordinary users can also information about what feature toggles are on for them.  This may be helpful for debugging.  We could also include on that page some other basic information such as which courses the student is registered for, their github uid, and anything else that might be helpful information when debugging.