### PR TITLE
pc - add test for mismatch in email case

### DIFF
--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -193,6 +193,24 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @enroll_success_flash_notice, flash[:notice]
   end
 
+
+  test "user can join class even if case of email doesn't match" do
+
+    user = @user
+    sign_in user
+    course = courses(:course2)
+
+    stub_find_user_in_org(user.username, course.course_organization, false)
+    stub_invite_user_to_org(user.username, course.course_organization)
+    stub_check_user_emails(user.email)
+    assert_difference('user.roster_students.count', 1) do
+      post course_join_path(course_id: course.id)
+    end
+    assert_redirected_to courses_url
+    enroll_success_flash_notice = %Q[You were successfully invited to #{course.name}! View and accept your invitation <a href="https://github.com/orgs/#{course.course_organization}/invitation">here</a>.]
+    assert_equal enroll_success_flash_notice, flash[:notice]
+  end
+
   test "roster student can NOT join class if NOT on class roster" do
 
     user_julie = users(:julie)

--- a/test/fixtures/roster_students.yml
+++ b/test/fixtures/roster_students.yml
@@ -20,6 +20,7 @@ roster3:
   perm: 123
   first_name: Wes
   last_name: P
-  email: wes@email.com
+  email: WES@email.com
   course: course2
   enrolled: false
+


### PR DESCRIPTION
A bug was reported by an instructor using the app, where a student's emai
email address on the course roster was in uppercase, but in practice
they always used lowercase.  In truth, email addresses are typically
case insensitive.   This test covers that.

It is written in the style of the tests currently in the test suite,
which is NOT the best style; it relies on fixtures far from the tests
themselves.  Refactoring that is a larger project; for now, we just needed
to get a test in to cover this case.